### PR TITLE
feat: rename platformConnect/platformConnectPublic methods to connect/connectPublic

### DIFF
--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/lib/BasicPrivmxEndpoint.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/lib/BasicPrivmxEndpoint.java
@@ -55,7 +55,7 @@ public class BasicPrivmxEndpoint implements AutoCloseable {
      *
      * @param enableModule   set of modules to initialize; should contain {@link Modules#THREAD }
      *                       to enable Thread module or {@link Modules#STORE } to enable Store module
-     * @param platformUrl        Platform's Endpoint URL
+     * @param bridgeUrl      Bridge's Endpoint URL
      * @param solutionId     {@code SolutionId} of the current project
      * @param userPrivateKey user private key used to authorize; generated from:
      *                       {@link CryptoApi#generatePrivateKey} or
@@ -68,9 +68,9 @@ public class BasicPrivmxEndpoint implements AutoCloseable {
             Set<Modules> enableModule,
             String userPrivateKey,
             String solutionId,
-            String platformUrl
+            String bridgeUrl
     ) throws IllegalStateException, PrivmxException, NativeException {
-        connection = Connection.platformConnect(userPrivateKey, solutionId, platformUrl);
+        connection = Connection.connect(userPrivateKey, solutionId, bridgeUrl);
         storeApi = enableModule.contains(Modules.STORE) ? new StoreApi(connection) : null;
         threadApi = enableModule.contains(Modules.THREAD) ? new ThreadApi(connection) : null;
         inboxApi = enableModule.contains(Modules.INBOX) ? new InboxApi(

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/lib/PrivmxEndpoint.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/lib/PrivmxEndpoint.java
@@ -44,7 +44,7 @@ public class PrivmxEndpoint extends BasicPrivmxEndpoint implements AutoCloseable
      *
      * @param enableModule   set of modules to initialize; should contain {@link Modules#THREAD }
      *                       to enable Thread module or {@link Modules#STORE } to enable Store module
-     * @param platformUrl        Platform's Endpoint URL
+     * @param bridgeUrl      Bridge's Endpoint URL
      * @param solutionId     {@code SolutionId} of the current project
      * @param userPrivateKey user private key used to authorize; generated from:
      *                       {@link CryptoApi#generatePrivateKey} or
@@ -57,9 +57,9 @@ public class PrivmxEndpoint extends BasicPrivmxEndpoint implements AutoCloseable
             Set<Modules> enableModule,
             String userPrivateKey,
             String solutionId,
-            String platformUrl
+            String bridgeUrl
     ) throws IllegalStateException, PrivmxException, NativeException {
-        super(enableModule, userPrivateKey, solutionId, platformUrl);
+        super(enableModule, userPrivateKey, solutionId, bridgeUrl);
     }
 
     /**

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/lib/PrivmxEndpointContainer.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/lib/PrivmxEndpointContainer.java
@@ -114,7 +114,7 @@ public class PrivmxEndpointContainer implements AutoCloseable {
      * Creates a new connection.
      *
      * @param enableModule   set of modules to initialize
-     * @param platformUrl        Platform's Endpoint URL
+     * @param bridgeUrl      Bridge's Endpoint URL
      * @param solutionId     {@code SolutionId} of the current project
      * @param userPrivateKey user private key used to authorize; generated from:
      *                       {@link CryptoApi#generatePrivateKey} or
@@ -128,14 +128,14 @@ public class PrivmxEndpointContainer implements AutoCloseable {
             Set<Modules> enableModule,
             String userPrivateKey,
             String solutionId,
-            String platformUrl
+            String bridgeUrl
     ) throws IllegalStateException, PrivmxException, NativeException {
         if (!isInitialized) throw new IllegalStateException("Certs path is not set");
         PrivmxEndpoint privmxEndpoint = new PrivmxEndpoint(
                 enableModule,
                 userPrivateKey,
                 solutionId,
-                platformUrl
+                bridgeUrl
         );
         synchronized (privmxEndpoints) {
             privmxEndpoints.put(privmxEndpoint.connection.getConnectionId(), privmxEndpoint);

--- a/privmx-endpoint/src/main/cpp/modules/Connection.cpp
+++ b/privmx-endpoint/src/main/cpp/modules/Connection.cpp
@@ -49,55 +49,6 @@ Java_com_simplito_java_privmx_1endpoint_modules_core_Connection_deinit(JNIEnv *e
 
 extern "C"
 JNIEXPORT jobject JNICALL
-Java_com_simplito_java_privmx_1endpoint_modules_core_Connection_platformConnect(
-        JNIEnv *env,
-        jclass clazz,
-        jstring user_priv_key,
-        jstring solution_id,
-        jstring platform_url
-) {
-    JniContextUtils ctx(env);
-    if (ctx.nullCheck(user_priv_key, "User Private Key") ||
-        ctx.nullCheck(solution_id, "Solution ID") ||
-        ctx.nullCheck(platform_url, "Platform URL")) {
-        return nullptr;
-    }
-    try {
-        jmethodID initMID = ctx->GetMethodID(clazz, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;)V");
-        privmx::endpoint::core::Connection connection = privmx::endpoint::core::Connection::platformConnect(
-                ctx.jString2string(user_priv_key),
-                ctx.jString2string(solution_id),
-                ctx.jString2string(platform_url)
-        );
-        privmx::endpoint::core::Connection *api = new privmx::endpoint::core::Connection();
-        *api = connection;
-        jobject result = ctx->NewObject(
-                clazz,
-                initMID,
-                ctx.long2jLong((jlong) api),
-                ctx.long2jLong(api->getConnectionId())
-        );
-        return result;
-    } catch (const privmx::endpoint::core::Exception &e) {
-        env->Throw(ctx.coreException2jthrowable(e));
-    } catch (const std::exception &e) {
-        env->ThrowNew(
-                env->FindClass(
-                        "com/simplito/java/privmx_endpoint/model/exceptions/NativeException"),
-                e.what()
-        );
-    } catch (...) {
-        env->ThrowNew(
-                env->FindClass(
-                        "com/simplito/java/privmx_endpoint/model/exceptions/NativeException"),
-                "Unknown exception"
-        );
-    }
-    return nullptr;
-}
-
-extern "C"
-JNIEXPORT jobject JNICALL
 Java_com_simplito_java_privmx_1endpoint_modules_core_Connection_listContexts(
         JNIEnv *env,
         jobject thiz,
@@ -236,22 +187,72 @@ Java_com_simplito_java_privmx_1endpoint_modules_core_Connection_setCertsPath(
 
 extern "C"
 JNIEXPORT jobject JNICALL
-Java_com_simplito_java_privmx_1endpoint_modules_core_Connection_platformConnectPublic(
+Java_com_simplito_java_privmx_1endpoint_modules_core_Connection_connect(
         JNIEnv *env,
         jclass clazz,
+        jstring user_priv_key,
         jstring solution_id,
-        jstring platform_url
+        jstring bridge_url
 ) {
     JniContextUtils ctx(env);
-    if (ctx.nullCheck(solution_id, "Solution ID") ||
-        ctx.nullCheck(platform_url, "Platform URL")) {
+    if (ctx.nullCheck(user_priv_key, "User Private Key") ||
+        ctx.nullCheck(solution_id, "Solution ID") ||
+        ctx.nullCheck(bridge_url, "Bridge URL")) {
         return nullptr;
     }
     try {
-        jmethodID initMID = ctx->GetMethodID(clazz, "<init>", "(Ljava/lang/Long;Ljava/lang/Long;)V");
-        privmx::endpoint::core::Connection connection = privmx::endpoint::core::Connection::platformConnectPublic(
+        jmethodID initMID = ctx->GetMethodID(clazz, "<init>",
+                                             "(Ljava/lang/Long;Ljava/lang/Long;)V");
+        privmx::endpoint::core::Connection connection = privmx::endpoint::core::Connection::connect(
+                ctx.jString2string(user_priv_key),
                 ctx.jString2string(solution_id),
-                ctx.jString2string(platform_url)
+                ctx.jString2string(bridge_url)
+        );
+        privmx::endpoint::core::Connection *api = new privmx::endpoint::core::Connection();
+        *api = connection;
+        jobject result = ctx->NewObject(
+                clazz,
+                initMID,
+                ctx.long2jLong((jlong) api),
+                ctx.long2jLong(api->getConnectionId())
+        );
+        return result;
+    } catch (const privmx::endpoint::core::Exception &e) {
+        env->Throw(ctx.coreException2jthrowable(e));
+    } catch (const std::exception &e) {
+        env->ThrowNew(
+                env->FindClass(
+                        "com/simplito/java/privmx_endpoint/model/exceptions/NativeException"),
+                e.what()
+        );
+    } catch (...) {
+        env->ThrowNew(
+                env->FindClass(
+                        "com/simplito/java/privmx_endpoint/model/exceptions/NativeException"),
+                "Unknown exception"
+        );
+    }
+    return nullptr;
+}
+extern "C"
+JNIEXPORT jobject JNICALL
+Java_com_simplito_java_privmx_1endpoint_modules_core_Connection_connectPublic(
+        JNIEnv *env,
+        jclass clazz,
+        jstring solution_id,
+        jstring bridge_url
+) {
+    JniContextUtils ctx(env);
+    if (ctx.nullCheck(solution_id, "Solution ID") ||
+        ctx.nullCheck(bridge_url, "Bridge URL")) {
+        return nullptr;
+    }
+    try {
+        jmethodID initMID = ctx->GetMethodID(clazz, "<init>",
+                                             "(Ljava/lang/Long;Ljava/lang/Long;)V");
+        privmx::endpoint::core::Connection connection = privmx::endpoint::core::Connection::connectPublic(
+                ctx.jString2string(solution_id),
+                ctx.jString2string(bridge_url)
         );
         privmx::endpoint::core::Connection *api = new privmx::endpoint::core::Connection();
         *api = connection;

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/Connection.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/Connection.java
@@ -60,7 +60,25 @@ public class Connection implements AutoCloseable {
      * channel: -
      * payload: {@link Void}
      */
-    public static native Connection platformConnect(String userPrivKey, String solutionId, String platformUrl) throws PrivmxException, NativeException;
+    @Deprecated
+    public static Connection platformConnect(String userPrivKey, String solutionId, String platformUrl) throws PrivmxException, NativeException{
+        return connect(userPrivKey,solutionId,platformUrl);
+    }
+
+    /**
+     * Connects to the PrivMX Bridge server.
+     *
+     * @param userPrivKey user's private key
+     * @param solutionId  ID of the Solution
+     * @param bridgeUrl Bridge's Endpoint URL
+     * @return Connection object
+     * @throws PrivmxException thrown when method encounters an exception.
+     * @throws NativeException thrown when method encounters an unknown exception.
+     * @event type: libConnected
+     * channel: -
+     * payload: {@link Void}
+     */
+    public static native Connection connect(String userPrivKey, String solutionId, String bridgeUrl) throws PrivmxException, NativeException;
 
     /**
      * Connects to the PrivMX Bridge server as a guest user.
@@ -74,7 +92,24 @@ public class Connection implements AutoCloseable {
      * channel: -
      * payload: {@link Void}
      */
-    public static native Connection platformConnectPublic(String solutionId, String platformUrl) throws PrivmxException, NativeException;
+    @Deprecated
+    public static Connection platformConnectPublic(String solutionId, String platformUrl) throws PrivmxException, NativeException{
+        return connectPublic(solutionId,platformUrl);
+    }
+
+    /**
+     * Connects to the PrivMX Bridge server as a guest user.
+     *
+     * @param solutionId  ID of the Solution
+     * @param bridgeUrl Bridge's Endpoint URL
+     * @return Connection object
+     * @throws PrivmxException thrown when method encounters an exception.
+     * @throws NativeException thrown when method encounters an unknown exception.
+     * @event type: libConnected
+     * channel: -
+     * payload: {@link Void}
+     */
+    public static native Connection connectPublic(String solutionId, String bridgeUrl) throws PrivmxException, NativeException;
 
     /**
      * Disconnects from the PrivMX Bridge server.

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/Connection.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/Connection.java
@@ -48,7 +48,7 @@ public class Connection implements AutoCloseable {
     public static native void setCertsPath(String certsPath) throws PrivmxException, NativeException;
 
     /**
-     * Connects to the PrivMX Bridge server.
+     * Connects to PrivMX Bridge server.
      *
      * @param userPrivKey user's private key
      * @param solutionId  ID of the Solution
@@ -66,7 +66,7 @@ public class Connection implements AutoCloseable {
     }
 
     /**
-     * Connects to the PrivMX Bridge server.
+     * Connects to PrivMX Bridge server.
      *
      * @param userPrivKey user's private key
      * @param solutionId  ID of the Solution
@@ -81,7 +81,7 @@ public class Connection implements AutoCloseable {
     public static native Connection connect(String userPrivKey, String solutionId, String bridgeUrl) throws PrivmxException, NativeException;
 
     /**
-     * Connects to the PrivMX Bridge server as a guest user.
+     * Connects to PrivMX Bridge server as a guest user.
      *
      * @param solutionId  ID of the Solution
      * @param platformUrl Platform's Endpoint URL
@@ -98,7 +98,7 @@ public class Connection implements AutoCloseable {
     }
 
     /**
-     * Connects to the PrivMX Bridge server as a guest user.
+     * Connects to PrivMX Bridge server as a guest user.
      *
      * @param solutionId  ID of the Solution
      * @param bridgeUrl Bridge's Endpoint URL
@@ -112,7 +112,7 @@ public class Connection implements AutoCloseable {
     public static native Connection connectPublic(String solutionId, String bridgeUrl) throws PrivmxException, NativeException;
 
     /**
-     * Disconnects from the PrivMX Bridge server.
+     * Disconnects from PrivMX Bridge server.
      *
      * @throws IllegalStateException thrown when instance is not connected or closed.
      * @throws PrivmxException       thrown when method encounters an exception.
@@ -167,7 +167,7 @@ public class Connection implements AutoCloseable {
 
 
     /**
-     * If there is an active connnection then it
+     * If there is an active connection then it
      * disconnects from PrivMX Bridge and frees memory making this instance not reusable.
      */
     @Override


### PR DESCRIPTION
## Description
Closes #3

Change method names in Connection.java:
1. `platformConnect` -> `connect`
2. `platformConnectPublic` -> `connectPublic`

## PrivMX Endpoint

### ADDITIONS

New methods:
- `connect(String userPrivKey, String solutionId, String bridgeUrl)`
- `connectPublic(String solutionId, String bridgeUrl)`

### MODIFICATIONS

Methods mark as deprecated and will be removed in next major (3.x):
- `platformConnect(String userPrivKey, String solutionId, String platformUrl)`
- `platformConnectPublic(String solutionId, String platformUrl)`

## PrivMX Endpoint Extra

### MODIFICATIONS

Rename parameter `platformUrl` to `bridgeUrl` in creating connection methods and constructors
