### PR TITLE
feat: implement inbox streaming api

### DIFF
--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 /**
  * Provides a streamlined process for creating and sending inbox entries
  * with optional file attachments.
- * <p> This class simplifies the complexities of interacting with the Inbox API for sending entries,
+ * <p> This class simplifies interacting with the Inbox API for sending entries,
  * especially when dealing with multiple files. It manages the lifecycle of the entry creation
  * process, including file uploads and final entry submission.
  *

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 /**
- * Provides a streamlined process for creating and sending inbox entries
+ * Provides a streamlined process for creating and sending Inbox entries
  * with optional file attachments.
  * <p> This class simplifies interacting with the Inbox API for sending entries,
  * especially when dealing with multiple files. It manages the lifecycle of the entry creation
@@ -65,13 +65,13 @@ public class InboxEntryStream {
      * Creates {@link InboxEntryStream} instance ready for streaming.
      * <p> This method initializes an {@link InboxEntryStream} and prepares it for sending
      * an entry with the provided data. It creates an Inbox handle and sets the
-     * initial state of the stream to {@link State#FILES_SENT}
+     * initial state of the stream to {@link State#FILES_SENT}.
      *
      * @param inboxApi            reference to Inbox API
      * @param inboxId             ID of the Inbox
-     * @param entryStreamListener the listener for stream state changes.
+     * @param entryStreamListener the listener for stream state changes
      * @param data                entry data to send
-     * @return instance of {@link InboxEntryStream} prepared for streaming.
+     * @return instance of {@link InboxEntryStream} prepared for streaming
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -84,15 +84,15 @@ public class InboxEntryStream {
 
     /**
      * Creates {@link InboxEntryStream} instance ready for streaming.
-     * <p>This method initializes an {@link InboxEntryStream} and prepares it for sending an entry with
+     * <p>This method initializes an {@link InboxEntryStream} and prepares it for sending an entry with the
      * associated files and empty data. It creates Inbox and file handles, setting the initial state of the stream
      * to {@link State#PREPARED}, indicating readiness for file transfer.
      *
      * @param inboxApi            reference to Inbox API
      * @param inboxId             ID of the Inbox
-     * @param entryStreamListener the listener for stream state changes.
-     * @param filesConfig         information about each entry's file to send.
-     * @return instance of {@link InboxEntryStream} prepared for streaming.
+     * @param entryStreamListener the listener for stream state changes
+     * @param filesConfig         information about each entry's file to send
+     * @return instance of {@link InboxEntryStream} prepared for streaming
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -114,8 +114,8 @@ public class InboxEntryStream {
      * @param inboxId             ID of the Inbox
      * @param entryStreamListener the listener for stream state changes
      * @param data                entry data to send
-     * @param filesConfig         information about each entry's file to send.
-     * @return instance of {@link InboxEntryStream} prepared for streaming.
+     * @param filesConfig         information about each entry's file to send
+     * @return instance of {@link InboxEntryStream} prepared for streaming
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -132,7 +132,7 @@ public class InboxEntryStream {
      * <p>This method initializes an {@link InboxEntryStream} and prepares it for sending an entry with the provided data,
      * optional associated files, and optional encryption using the sender's private key. It creates an Inbox handle
      * and initializes file handles for any associated files. The initial state of the stream is determined based
-     * on the presence of files: if no files are provided, the state is set to {@link State#FILES_SENT}; otherwise,
+     * on the presence of files: if no files are provided, the state is set to {@link State#FILES_SENT}. Otherwise,
      * it's set to {@link State#PREPARED}, indicating readiness for file transfer.
      *
      * @param inboxApi            reference to Inbox API
@@ -141,7 +141,7 @@ public class InboxEntryStream {
      * @param data                entry data to send
      * @param filesConfig         information about each entry's file to send
      * @param userPrivKey         sender's private key which can be used later to encrypt data for that sender
-     * @return instance of {@link InboxEntryStream} prepared for streaming.
+     * @return instance of {@link InboxEntryStream} prepared for streaming
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -322,8 +322,8 @@ public class InboxEntryStream {
      * <p>This method should only be called after all files associated with the entry have been
      * successfully sent, indicated by the stream being in the {@link State#FILES_SENT} state.
      *
-     * @throws PrivmxException       when method encounters an exception during call {@link InboxApi#sendEntry} method
-     * @throws NativeException       when method encounters an unknown exception during call {@link InboxApi#sendEntry} method
+     * @throws PrivmxException       when method encounters an exception while calling {@link InboxApi#sendEntry} method
+     * @throws NativeException       when method encounters an unknown exception while calling {@link InboxApi#sendEntry} method
      * @throws IllegalStateException if the stream is not in the {@link State#FILES_SENT} state
      */
     public synchronized void sendEntry() throws PrivmxException, NativeException, IllegalStateException {
@@ -354,15 +354,15 @@ public class InboxEntryStream {
          */
         FILES_SENT,
         /**
-         * Indicates that an error occurred during the process of sending files or the Entry.
+         * Indicates that an error occurred while sending files or the Entry.
          */
         ERROR,
         /**
-         * Indicates that the entry has been sent successfully.
+         * Indicates that the entry was sent successfully.
          */
         SENT,
         /**
-         * Indicates that the {@link InboxEntryStream} has been canceled.
+         * Indicates that the {@link InboxEntryStream} was canceled.
          */
         ABORTED
     }
@@ -419,7 +419,7 @@ public class InboxEntryStream {
     /**
      * Interface for listening to state changes and exchanging data with an {@link InboxEntryStream} instance.
      * <p>
-     * This interface provides callbacks for various events that occur during the lifecycle of an inbox entry stream,
+     * This interface provides callbacks for various events that occur during the lifecycle of an Inbox entry stream,
      * such as starting and ending file sending, requesting file chunks, handling errors, and updating the stream state.
      * <p>
      * Implement this interface to monitor and interact with the entry stream.
@@ -429,14 +429,14 @@ public class InboxEntryStream {
         /**
          * Override this method to handle when file start sending.
          *
-         * @param file information about the file being sent
+         * @param file information about the sent file
          */
         public void onStartFileSending(FileInfo file) {
 
         }
 
         /**
-         * Override this method to handle when file has been send successfully.
+         * Override this method to handle when file was sent successfully.
          *
          * @param file information about the sent file
          */
@@ -449,20 +449,20 @@ public class InboxEntryStream {
          * and the stream requests a chunk of the file to send.
          * <p>This method should return the next chunk of the file.
          * <p>Returning {@code null} will cause a
-         * {@link NullPointerException} during file sending and stop the {@link InboxEntryStream} instance with
+         * {@link NullPointerException} while sending the file and stop the {@link InboxEntryStream} instance with
          * the state {@link State#ERROR}.
          *
-         * @param file info about file for which chunk is requested
-         * @return next chunk of file.
+         * @param file info about the file, which chunk is requested
+         * @return next chunk of the file
          */
         public byte[] onNextChunkRequest(FileInfo file) {
             return null;
         }
 
         /**
-         * Override this method to handle event when each chunk of a file has been sent successfully.
+         * Override this method to handle event when each chunk of a file was sent successfully.
          *
-         * @param file           information about the file for which the chunk was processed
+         * @param file           information about the file, which chunk was processed
          * @param processedBytes accumulated size of sent data
          */
         public void onFileChunkProcessed(FileInfo file, long processedBytes) {
@@ -470,19 +470,19 @@ public class InboxEntryStream {
         }
 
         /**
-         * Override this method to handle event when some error occurs during file sending.
+         * Override this method to handle event when an error occurs while sending files.
          *
          * @param file      information about the file that caused the error
-         * @param throwable exception that occurred during file sending
+         * @param throwable exception that occurred while sending files
          */
         public void onErrorDuringSending(FileInfo file, Throwable throwable) {
 
         }
 
         /**
-         * Override this method to handle event when some error occurs during creating entry.
+         * Override this method to handle event when an error occurs while creating entry.
          *
-         * @param throwable exception that occurred during entry creation
+         * @param throwable exception that occurred while creating an entry
          */
         public void onError(Throwable throwable) {
 

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
@@ -1,0 +1,326 @@
+//
+// PrivMX Endpoint Java Extra.
+// Copyright © 2024 Simplito sp. z o.o.
+//
+// This file is part of the PrivMX Platform (https://privmx.dev).
+// This software is Licensed under the MIT License.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.simplito.java.privmx_endpoint_extra.inboxEntryStream;
+
+import com.simplito.java.privmx_endpoint.model.exceptions.NativeException;
+import com.simplito.java.privmx_endpoint.model.exceptions.PrivmxException;
+import com.simplito.java.privmx_endpoint.modules.inbox.InboxApi;
+import com.simplito.java.privmx_endpoint_extra.inboxFileStream.InboxFileStreamWriter;
+import com.simplito.java.privmx_endpoint_extra.storeFileStream.StoreFileStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+public class InboxEntryStream {
+    private final InboxApi inboxApi;
+    private final Map<FileInfo, InboxFileStreamWriter> inboxFiles;
+    private final long inboxHandle;
+    private final EntryStreamListener entryStreamListener;
+    private final List<Future<?>> sendingFiles = new ArrayList<>();
+    private State streamState = State.PREPARED;
+
+    private InboxEntryStream(InboxApi api, Map<FileInfo, InboxFileStreamWriter> inboxFiles, long inboxHandle, EntryStreamListener entryStreamListener) {
+        Objects.requireNonNull(inboxFiles);
+        Objects.requireNonNull(entryStreamListener);
+        this.inboxApi = api;
+        this.inboxFiles = inboxFiles;
+        this.inboxHandle = inboxHandle;
+        this.entryStreamListener = entryStreamListener;
+        if (inboxFiles.isEmpty()) {
+            streamState = State.FILES_SENT;
+        }
+    }
+
+    public static InboxEntryStream prepareEntry(
+            InboxApi inboxApi,
+            String inboxId,
+            EntryStreamListener entryStreamListener,
+            byte[] data
+    ) {
+        return prepareEntry(inboxApi, inboxId, entryStreamListener, data, null);
+    }
+
+    public static InboxEntryStream prepareEntry(
+            InboxApi inboxApi,
+            String inboxId,
+            EntryStreamListener entryStreamListener,
+            List<FileInfo> filesConfig
+    ) {
+        return prepareEntry(inboxApi, inboxId, entryStreamListener, "".getBytes(StandardCharsets.UTF_8), filesConfig);
+    }
+
+    public static InboxEntryStream prepareEntry(
+            InboxApi inboxApi,
+            String inboxId,
+            EntryStreamListener entryStreamListener,
+            byte[] data,
+            List<FileInfo> filesConfig
+    ) {
+        return prepareEntry(inboxApi, inboxId, entryStreamListener, data, filesConfig, null);
+    }
+
+    public static InboxEntryStream prepareEntry(
+            InboxApi inboxApi,
+            String inboxId,
+            EntryStreamListener entryStreamListener,
+            byte[] data,
+            List<FileInfo> filesConfig,
+            String userPrivKey
+    ) {
+        Map<FileInfo, InboxFileStreamWriter> files = Optional.ofNullable(filesConfig)
+                .orElse(Collections.emptyList())
+                .stream()
+                .collect(
+                        Collectors.toMap(
+                                fileInfo -> fileInfo,
+                                config -> InboxFileStreamWriter.createFile(
+                                        inboxApi,
+                                        config.publicMeta,
+                                        config.privateMeta,
+                                        config.fileSize
+                                )
+                        )
+                );
+        List<Long> fileHandles = files.values().stream().map(InboxFileStreamWriter::getFileHandle).collect(Collectors.toList());
+        Long inboxHandle = inboxApi.prepareEntry(inboxId, data, fileHandles, userPrivKey);
+        return new InboxEntryStream(inboxApi, files, inboxHandle, entryStreamListener);
+    }
+
+    public synchronized void sendFiles(
+            ExecutorService fileStreamExecutor
+    ) {
+        if (streamState != State.PREPARED) {
+            throw new IllegalStateException("Stream should be in state PREPARED. Current state is: " + streamState.name());
+        }
+        if (!sendingFiles.isEmpty()) {
+            throw new IllegalStateException("Uploading files in progress");
+        }
+        inboxFiles.forEach((fileInfo, fileHandle) -> {
+            sendingFiles.add(fileStreamExecutor.submit(() -> {
+                try {
+                    sendFile(fileInfo, fileHandle);
+                    entryStreamListener.onEndFileSending(fileInfo);
+                } catch (Exception e) {
+                    stopFileStreams();
+                    onError(e);
+                    entryStreamListener.onErrorDuringSending(fileInfo, e);
+                }
+            }));
+        });
+        System.out.println("Start waiting 2");
+        for (Future<?> future : sendingFiles) {
+            if (Thread.interrupted()) {
+                cancel();
+                return;
+            }
+            try {
+                future.get();
+            } catch (InterruptedException | CancellationException e) {
+                // catch when in async mode someone call cancel on result Future.
+                cancel();
+                return;
+            } catch (Exception e) {
+                System.out.println("Break waiting on other exception");
+            }
+        }
+        if (sendingFiles.stream().allMatch(Future::isDone)) {
+            updateState(State.FILES_SENT);
+        } else {
+            onError(new IllegalStateException("Some files cannot be sent"));
+        }
+
+    }
+
+    private void sendFile(
+            FileInfo fileInfo,
+            InboxFileStreamWriter fileHandle
+    ) throws PrivmxException, NativeException, IllegalStateException, IOException {
+        final StoreFileStream.Controller controller = new StoreFileStream.Controller() {
+            @Override
+            public void onChunkProcessed(Long processedBytes) {
+                entryStreamListener.onFileChunkProcessed(fileInfo, processedBytes);
+                if (Thread.interrupted()) {
+                    this.stop();
+                }
+            }
+        };
+
+        entryStreamListener.onStartFileSending(fileInfo);
+        if (fileInfo.fileStream == null) {
+            fileHandle.setProgressListener(controller);
+            while (fileInfo.fileSize > fileHandle.getProcessedBytes() && !fileHandle.isClosed()) {
+                if (controller.isStopped()) {
+                    break;
+                }
+                fileHandle.write(inboxHandle, entryStreamListener.onNextChunkRequest(fileInfo));
+            }
+        } else {
+            fileHandle.writeStream(inboxHandle, fileInfo.fileStream, controller);
+        }
+    }
+
+    public void onError(Throwable t) {
+        cancel();
+        stopFileStreams();
+        closeFileHandles();
+        updateState(State.ERROR);
+        entryStreamListener.onError(t);
+    }
+
+    private void updateState(State newState) {
+        if (streamState != newState) {
+            synchronized (this) {
+                streamState = newState;
+                entryStreamListener.onUpdateState(streamState);
+            }
+        }
+    }
+
+    public void cancel() {
+        if (streamState == State.ERROR) return;
+        if (streamState == State.ABORTED) return;
+        synchronized (this) {
+            stopFileStreams();
+            closeFileHandles();
+            if (streamState != State.SENT) {
+                updateState(State.ABORTED);
+            }
+        }
+    }
+
+    private void stopFileStreams() {
+        if (streamState == State.PREPARED && !sendingFiles.isEmpty()) {
+            synchronized (sendingFiles) {
+                sendingFiles.forEach((task) -> {
+                    task.cancel(true);
+                });
+            }
+        }
+    }
+
+    private void closeFileHandles() {
+        synchronized (inboxFiles) {
+            inboxFiles.values().forEach(file -> {
+                try {
+                    if (!file.isClosed()) {
+                        file.close();
+                    }
+                } catch (Exception ignore) {
+                }
+            });
+        }
+    }
+
+    public void sendFiles() {
+        try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+            sendFiles(executor);
+        }
+    }
+
+    public synchronized void sendEntry() throws PrivmxException, NativeException, IllegalStateException {
+        if (streamState != State.FILES_SENT) {
+            throw new IllegalStateException("Stream should be in state FILES_SENT. Current state is: " + streamState.name());
+        }
+        try {
+            inboxApi.sendEntry(inboxHandle);
+            updateState(State.SENT);
+        } catch (Exception e) {
+            onError(e);
+        }
+    }
+
+    public enum State {
+        /**
+         * The initial state, indicating that {@link InboxEntryStream} is ready to send files.
+         */
+        PREPARED,
+        /**
+         * Indicates that all files have been sent successfully and the entry is ready to be sent.
+         * This state is set when:
+         * 1. The {@link InboxEntryStream} has been initialized and there are no files to send.
+         * 2. All files have been sent successfully.
+         */
+        FILES_SENT,
+        /**
+         * Indicates that an error occurred during the process of sending files or the Entry.
+         */
+        ERROR,
+        /**
+         * Indicates that the entry has been sent successfully.
+         */
+        SENT,
+        /**
+         * Indicates that the {@link InboxEntryStream} has been canceled.
+         */
+        ABORTED
+    }
+
+    public static class FileInfo {
+        public byte[] publicMeta;
+        public byte[] privateMeta;
+        public long fileSize;
+        public InputStream fileStream;
+
+        public FileInfo(
+                byte[] publicMeta,
+                byte[] privateMeta,
+                long fileSize,
+                InputStream fileStream
+        ) {
+            this.publicMeta = publicMeta;
+            this.privateMeta = privateMeta;
+            this.fileSize = fileSize;
+            this.fileStream = fileStream;
+        }
+    }
+
+    public abstract static class EntryStreamListener {
+        public void onStartFileSending(FileInfo file) {
+        }
+
+        public void onEndFileSending(FileInfo file) {
+
+        }
+
+        public byte[] onNextChunkRequest(FileInfo file) {
+            return null;
+        }
+
+        public void onFileChunkProcessed(FileInfo file, long chunk) {
+
+        }
+
+        public void onErrorDuringSending(FileInfo file, Throwable throwable) {
+
+        }
+
+        public void onError(Throwable t) {
+
+        }
+
+        public void onUpdateState(State currentState) {
+
+        }
+    }
+}

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
@@ -427,9 +427,9 @@ public class InboxEntryStream {
     public abstract static class EntryStreamListener {
 
         /**
-         * Override this method to handle when file start sending.
+         * Override this method to handle when the process of sending file starts.
          *
-         * @param file information about the sent file
+         * @param file information about the file being sent
          */
         public void onStartFileSending(FileInfo file) {
 

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStream.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStream.java
@@ -1,0 +1,107 @@
+//
+// PrivMX Endpoint Java Extra.
+// Copyright © 2024 Simplito sp. z o.o.
+//
+// This file is part of the PrivMX Platform (https://privmx.dev).
+// This software is Licensed under the MIT License.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.simplito.java.privmx_endpoint_extra.inboxFileStream;
+
+import com.simplito.java.privmx_endpoint.model.exceptions.NativeException;
+import com.simplito.java.privmx_endpoint.model.exceptions.PrivmxException;
+import com.simplito.java.privmx_endpoint.modules.inbox.InboxApi;
+import com.simplito.java.privmx_endpoint_extra.storeFileStream.StoreFileStream;
+import com.simplito.java.privmx_endpoint_extra.storeFileStream.StoreFileStream.ProgressListener;
+
+/**
+ * Base class for Store file streams. Implements progress listeners.
+ *
+ * @category store
+ */
+public abstract class InboxFileStream {
+    /**
+     * Constant value with optimal size of reading/sending data.
+     */
+    public static final long OPTIMAL_SEND_SIZE = 128 * 1024L;
+    /**
+     * Reference to file handle.
+     */
+    protected final Long handle;
+    /**
+     * Reference to {@link com.simplito.java.privmx_endpoint.modules.inbox.InboxApi}.
+     */
+    protected final InboxApi inboxApi;
+    private Long processedBytes = 0L;
+    private StoreFileStream.ProgressListener progressListener;
+    private Boolean closed = false;
+
+    /**
+     * Creates instance of {@code StoreFileStream}.
+     *
+     * @param handle   handle to Store file
+     * @param inboxApi {@link InboxApi} instance that calls read/write methods on files
+     */
+    protected InboxFileStream(
+            Long handle,
+            InboxApi inboxApi
+    ) {
+        this.handle = handle;
+        this.inboxApi = inboxApi;
+    }
+
+    public Long getFileHandle() {
+        return handle;
+    }
+
+    /**
+     * Sets listening for single chunk sent/read.
+     *
+     * @param progressListener callback triggered when chunk is sent/read
+     */
+    public void setProgressListener(ProgressListener progressListener) {
+        this.progressListener = progressListener;
+    }
+
+    /**
+     * Increases the size of current sent/read data by chunkSize and calls {@link StoreFileStream.ProgressListener#onChunkProcessed(Long)}.
+     *
+     * @param chunkSize size of processed chunk
+     */
+    protected void callChunkProcessed(Long chunkSize) {
+        processedBytes += chunkSize;
+        if (progressListener != null) {
+            progressListener.onChunkProcessed(processedBytes);
+        }
+    }
+
+    public Long getProcessedBytes() {
+        return this.processedBytes;
+    }
+
+    /**
+     * Returns information whether the instance is closed.
+     *
+     * @return {@code true} if file handle is closed
+     */
+    public Boolean isClosed() {
+        return closed;
+    }
+
+    /**
+     * Closes file handle.
+     *
+     * @return ID of the closed file
+     * @throws PrivmxException       if there is an error while closing file
+     * @throws NativeException       if there is an unknown error while closing file
+     * @throws IllegalStateException when {@code storeApi} is not initialized or there's no connection
+     */
+    public synchronized String close() throws PrivmxException, NativeException, IllegalStateException {
+        String result = inboxApi.closeFile(handle);
+        closed = true;
+        return result;
+    }
+}

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStream.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStream.java
@@ -18,31 +18,35 @@ import com.simplito.java.privmx_endpoint_extra.storeFileStream.StoreFileStream;
 import com.simplito.java.privmx_endpoint_extra.storeFileStream.StoreFileStream.ProgressListener;
 
 /**
- * Base class for Store file streams. Implements progress listeners.
+ * Base class for Inbox file streams.
  *
- * @category store
+ * @category inbox
  */
 public abstract class InboxFileStream {
+
     /**
      * Constant value with optimal size of reading/sending data.
      */
     public static final long OPTIMAL_SEND_SIZE = 128 * 1024L;
+
     /**
      * Reference to file handle.
      */
     protected final Long handle;
+
     /**
-     * Reference to {@link com.simplito.java.privmx_endpoint.modules.inbox.InboxApi}.
+     * Reference to {@link com.simplito.java.privmx_endpoint.modules.inbox.InboxApi} instance.
      */
     protected final InboxApi inboxApi;
+
     private Long processedBytes = 0L;
     private StoreFileStream.ProgressListener progressListener;
     private Boolean closed = false;
 
     /**
-     * Creates instance of {@code StoreFileStream}.
+     * Creates instance of {@link InboxFileStream}.
      *
-     * @param handle   handle to Store file
+     * @param handle   handle to Inbox file
      * @param inboxApi {@link InboxApi} instance that calls read/write methods on files
      */
     protected InboxFileStream(
@@ -53,6 +57,11 @@ public abstract class InboxFileStream {
         this.inboxApi = inboxApi;
     }
 
+    /**
+     * Gets current file handle.
+     *
+     * @return file handle.
+     */
     public Long getFileHandle() {
         return handle;
     }
@@ -78,6 +87,11 @@ public abstract class InboxFileStream {
         }
     }
 
+    /**
+     * Gets size of sent data.
+     *
+     * @return size of sent data.
+     */
     public Long getProcessedBytes() {
         return this.processedBytes;
     }
@@ -97,7 +111,7 @@ public abstract class InboxFileStream {
      * @return ID of the closed file
      * @throws PrivmxException       if there is an error while closing file
      * @throws NativeException       if there is an unknown error while closing file
-     * @throws IllegalStateException when {@code storeApi} is not initialized or there's no connection
+     * @throws IllegalStateException when {@link #inboxApi} is not initialized or there's no connection
      */
     public synchronized String close() throws PrivmxException, NativeException, IllegalStateException {
         String result = inboxApi.closeFile(handle);

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamReader.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamReader.java
@@ -1,0 +1,141 @@
+//
+// PrivMX Endpoint Java Extra.
+// Copyright © 2024 Simplito sp. z o.o.
+//
+// This file is part of the PrivMX Platform (https://privmx.dev).
+// This software is Licensed under the MIT License.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.simplito.java.privmx_endpoint_extra.inboxFileStream;
+
+import com.simplito.java.privmx_endpoint.model.exceptions.NativeException;
+import com.simplito.java.privmx_endpoint.model.exceptions.PrivmxException;
+import com.simplito.java.privmx_endpoint.modules.inbox.InboxApi;
+import com.simplito.java.privmx_endpoint_extra.storeFileStream.StoreFileStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * Manages handle for file reading.
+ *
+ * @category inbox
+ */
+public class InboxFileStreamReader extends InboxFileStream {
+
+
+    private InboxFileStreamReader(
+            Long handle,
+            InboxApi api
+    ) {
+        super(handle, api);
+    }
+
+    /**
+     * Opens Inbox file.
+     *
+     * @param api    reference to Inbox API
+     * @param fileId ID of the file to open
+     * @return Instance ready to read from the Inbox file
+     * @throws IllegalStateException when {@code inboxApi} is not initialized or there's no connection
+     * @throws PrivmxException       if there is an error while opening Inbox file
+     * @throws NativeException       if there is an unknown error while opening Inbox file
+     */
+    public static InboxFileStreamReader openFile(
+            InboxApi api,
+            String fileId
+    ) throws IllegalStateException, PrivmxException, NativeException {
+        return new InboxFileStreamReader(
+                api.openFile(fileId),
+                api
+        );
+    }
+
+    /**
+     * Opens Inbox file and writes it into {@link OutputStream}.
+     *
+     * @param api          reference to Inbox API
+     * @param fileId       ID of the file to open
+     * @param outputStream stream to write downloaded data with optimized chunk size {@link  InboxFileStream#OPTIMAL_SEND_SIZE}
+     * @return ID of the read file
+     * @throws IOException           if there is an error while writing the stream
+     * @throws IllegalStateException when inboxApi is not initialized or there's no connection
+     * @throws PrivmxException       if there is an error while opening Inbox file
+     * @throws NativeException       if there is an unknown error while opening Inbox file
+     */
+    public static String openFile(
+            InboxApi api,
+            String fileId,
+            OutputStream outputStream
+    ) throws IOException, IllegalStateException, PrivmxException, NativeException {
+        return InboxFileStreamReader.openFile(api, fileId, outputStream, null);
+    }
+
+    /**
+     * Opens Inbox file and writes it into {@link OutputStream}.
+     *
+     * @param api              reference to Inbox API
+     * @param fileId           ID of the file to open
+     * @param outputStream     stream to write downloaded data with optimized chunk size {@link  InboxFileStream#OPTIMAL_SEND_SIZE}
+     * @param streamController controls the process of reading file
+     * @return ID of the read file
+     * @throws IOException           if there is an error while writing stream
+     * @throws IllegalStateException when inboxApi is not initialized or there's no connection
+     * @throws PrivmxException       if there is an error while reading Inbox file
+     * @throws NativeException       if there is an unknown error while reading Inbox file
+     */
+    public static String openFile(
+            InboxApi api,
+            String fileId,
+            OutputStream outputStream,
+            StoreFileStream.Controller streamController
+    ) throws IOException, IllegalStateException, PrivmxException, NativeException {
+        InboxFileStreamReader input = InboxFileStreamReader.openFile(api, fileId);
+        if (streamController != null) {
+            input.setProgressListener(streamController);
+        }
+        byte[] chunk;
+        do {
+            if (streamController != null && streamController.isStopped()) {
+                input.close();
+            }
+            chunk = input.read(InboxFileStream.OPTIMAL_SEND_SIZE);
+            outputStream.write(chunk);
+        } while (chunk.length == InboxFileStream.OPTIMAL_SEND_SIZE);
+
+        return input.close();
+    }
+
+    /**
+     * Reads file data and moves the cursor. If read data size is less than length, then EOF.
+     *
+     * @param size size of data to read (the recommended size is {@link  InboxFileStream#OPTIMAL_SEND_SIZE})
+     * @return Read data
+     * @throws IOException           when {@code this} is closed
+     * @throws PrivmxException       when method encounters an exception
+     * @throws NativeException       when method encounters an unknown exception
+     * @throws IllegalStateException when {@link #inboxApi} is closed
+     */
+    public byte[] read(Long size) throws IOException, PrivmxException, NativeException, IllegalStateException {
+        if (isClosed()) throw new IOException("File handle is closed");
+        byte[] result = inboxApi.readFromFile(handle, size);
+        callChunkProcessed((long) result.length);
+        return result;
+    }
+
+    /**
+     * Moves read cursor.
+     *
+     * @param position new cursor position
+     * @throws IllegalStateException if {@code inboxApi} is not initialized or connected
+     * @throws PrivmxException       if there is an error while seeking
+     * @throws NativeException       if there is an unknown error while seeking
+     */
+    public void seek(long position) throws IllegalStateException, PrivmxException, NativeException {
+        inboxApi.seekInFile(handle, position);
+    }
+}

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamReader.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamReader.java
@@ -21,12 +21,11 @@ import java.io.OutputStream;
 
 
 /**
- * Manages handle for file reading.
+ * Manages handle for file reading from Inbox.
  *
  * @category inbox
  */
 public class InboxFileStreamReader extends InboxFileStream {
-
 
     private InboxFileStreamReader(
             Long handle,
@@ -56,11 +55,11 @@ public class InboxFileStreamReader extends InboxFileStream {
     }
 
     /**
-     * Opens Inbox file and writes it into {@link OutputStream}.
+     * Opens Inbox file and writes it into {@link OutputStream} with optimized chunk size {@link  InboxFileStream#OPTIMAL_SEND_SIZE}.
      *
      * @param api          reference to Inbox API
      * @param fileId       ID of the file to open
-     * @param outputStream stream to write downloaded data with optimized chunk size {@link  InboxFileStream#OPTIMAL_SEND_SIZE}
+     * @param outputStream stream to write downloaded data
      * @return ID of the read file
      * @throws IOException           if there is an error while writing the stream
      * @throws IllegalStateException when inboxApi is not initialized or there's no connection
@@ -76,11 +75,11 @@ public class InboxFileStreamReader extends InboxFileStream {
     }
 
     /**
-     * Opens Inbox file and writes it into {@link OutputStream}.
+     * Opens Inbox file and writes it into {@link OutputStream} with optimized chunk size {@link  InboxFileStream#OPTIMAL_SEND_SIZE}.
      *
      * @param api              reference to Inbox API
      * @param fileId           ID of the file to open
-     * @param outputStream     stream to write downloaded data with optimized chunk size {@link  InboxFileStream#OPTIMAL_SEND_SIZE}
+     * @param outputStream     stream to write downloaded data
      * @param streamController controls the process of reading file
      * @return ID of the read file
      * @throws IOException           if there is an error while writing stream

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
@@ -59,14 +59,14 @@ public class InboxFileStreamWriter extends InboxFileStream {
     /**
      * Writes data to Inbox file.
      *
-     * @param inboxHandle the handle of an Inbox to write to
+     * @param inboxHandle the handle of the Inbox to write to
      * @param data        data to write (the recommended size of data chunk is {@link InboxFileStream#OPTIMAL_SEND_SIZE})
      * @throws PrivmxException       if there is an error while writing chunk
      * @throws NativeException       if there is an unknown error while writing chunk
      * @throws IllegalStateException when inboxApi is not initialized or there's no connection
      * @throws IOException           when {@code this} is closed
-     * @throws PrivmxException       when method encounters an exception during execution of {@link InboxApi#writeToFile}
-     * @throws NativeException       when method encounters an unknown exception during execution of {@link InboxApi#writeToFile}
+     * @throws PrivmxException       when method encounters an exception while executing {@link InboxApi#writeToFile}
+     * @throws NativeException       when method encounters an unknown exception while executing {@link InboxApi#writeToFile}
      * @throws IllegalStateException when {@link #inboxApi} is closed
      */
     public void write(long inboxHandle, byte[] data) throws PrivmxException, NativeException, IllegalStateException, IOException {
@@ -80,8 +80,8 @@ public class InboxFileStreamWriter extends InboxFileStream {
      *
      * @param inboxHandle the handle of an Inbox to write to
      * @param inputStream the {@link InputStream} to read data from
-     * @throws PrivmxException       when method encounters an exception during execution of {@link InboxApi#writeToFile}
-     * @throws NativeException       when method encounters an unknown exception during execution of {@link InboxApi#writeToFile}
+     * @throws PrivmxException       when method encounters an exception while executing {@link InboxApi#writeToFile}
+     * @throws NativeException       when method encounters an unknown exception while executing {@link InboxApi#writeToFile}
      * @throws IllegalStateException when {@link #inboxApi} is closed
      * @throws IOException           when {@link InputStream#read} thrown exception
      */
@@ -92,11 +92,11 @@ public class InboxFileStreamWriter extends InboxFileStream {
     /**
      * Writes data from an {@link InputStream} to an Inbox file.
      *
-     * @param inboxHandle      the handle of an Inbox to write to
+     * @param inboxHandle      the handle of the Inbox to write to
      * @param inputStream      the {@link InputStream} to read data from
      * @param streamController an optional controller for monitoring and controlling the write operation.
-     * @throws PrivmxException       when method encounters an exception during execution of {@link InboxApi#writeToFile}
-     * @throws NativeException       when method encounters an unknown exception during execution of {@link InboxApi#writeToFile}
+     * @throws PrivmxException       when method encounters an exception while executing {@link InboxApi#writeToFile}
+     * @throws NativeException       when method encounters an unknown exception while executing {@link InboxApi#writeToFile}
      * @throws IllegalStateException when {@link #inboxApi} is closed
      * @throws IOException           when {@link InputStream#read} thrown exception
      */

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
@@ -59,13 +59,14 @@ public class InboxFileStreamWriter extends InboxFileStream {
     /**
      * Writes data to Inbox file.
      *
-     * @param data data to write (the recommended size of data chunk is {@link InboxFileStream#OPTIMAL_SEND_SIZE})
+     * @param inboxHandle the handle of an Inbox to write to
+     * @param data        data to write (the recommended size of data chunk is {@link InboxFileStream#OPTIMAL_SEND_SIZE})
      * @throws PrivmxException       if there is an error while writing chunk
      * @throws NativeException       if there is an unknown error while writing chunk
      * @throws IllegalStateException when inboxApi is not initialized or there's no connection
      * @throws IOException           when {@code this} is closed
-     * @throws PrivmxException       when method encounters an exception
-     * @throws NativeException       when method encounters an unknown exception
+     * @throws PrivmxException       when method encounters an exception during execution of {@link InboxApi#writeToFile}
+     * @throws NativeException       when method encounters an unknown exception during execution of {@link InboxApi#writeToFile}
      * @throws IllegalStateException when {@link #inboxApi} is closed
      */
     public void write(long inboxHandle, byte[] data) throws PrivmxException, NativeException, IllegalStateException, IOException {
@@ -74,10 +75,31 @@ public class InboxFileStreamWriter extends InboxFileStream {
         callChunkProcessed((long) data.length);
     }
 
-    public void writeStream(long inboxHandle, InputStream stream) throws PrivmxException, NativeException, IllegalStateException, IOException {
-        writeStream(inboxHandle, stream, null);
+    /**
+     * Writes data from an {@link InputStream} to an Inbox file.
+     *
+     * @param inboxHandle the handle of an Inbox to write to
+     * @param inputStream the {@link InputStream} to read data from
+     * @throws PrivmxException       when method encounters an exception during execution of {@link InboxApi#writeToFile}
+     * @throws NativeException       when method encounters an unknown exception during execution of {@link InboxApi#writeToFile}
+     * @throws IllegalStateException when {@link #inboxApi} is closed
+     * @throws IOException           when {@link InputStream#read} thrown exception
+     */
+    public void writeStream(long inboxHandle, InputStream inputStream) throws PrivmxException, NativeException, IllegalStateException, IOException {
+        writeStream(inboxHandle, inputStream, null);
     }
 
+    /**
+     * Writes data from an {@link InputStream} to an Inbox file.
+     *
+     * @param inboxHandle      the handle of an Inbox to write to
+     * @param inputStream      the {@link InputStream} to read data from
+     * @param streamController an optional controller for monitoring and controlling the write operation.
+     * @throws PrivmxException       when method encounters an exception during execution of {@link InboxApi#writeToFile}
+     * @throws NativeException       when method encounters an unknown exception during execution of {@link InboxApi#writeToFile}
+     * @throws IllegalStateException when {@link #inboxApi} is closed
+     * @throws IOException           when {@link InputStream#read} thrown exception
+     */
     public void writeStream(long inboxHandle, InputStream inputStream, StoreFileStream.Controller streamController) throws PrivmxException, NativeException, IllegalStateException, IOException {
         if (streamController != null) {
             setProgressListener(streamController);

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
@@ -1,0 +1,97 @@
+//
+// PrivMX Endpoint Java Extra.
+// Copyright © 2024 Simplito sp. z o.o.
+//
+// This file is part of the PrivMX Platform (https://privmx.dev).
+// This software is Licensed under the MIT License.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.simplito.java.privmx_endpoint_extra.inboxFileStream;
+
+import com.simplito.java.privmx_endpoint.model.exceptions.NativeException;
+import com.simplito.java.privmx_endpoint.model.exceptions.PrivmxException;
+import com.simplito.java.privmx_endpoint.modules.inbox.InboxApi;
+import com.simplito.java.privmx_endpoint_extra.storeFileStream.StoreFileStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * Manages handle for file writing.
+ *
+ * @category inbox
+ */
+public class InboxFileStreamWriter extends InboxFileStream {
+
+    private InboxFileStreamWriter(Long handle, InboxApi inboxApi) {
+        super(handle, inboxApi);
+    }
+
+    /**
+     * Creates a new file in given Inbox.
+     *
+     * @param api         reference to Inbox API
+     * @param publicMeta  byte array of any arbitrary metadata that can be read by anyone
+     * @param privateMeta byte array of any arbitrary metadata that will be encrypted before sending
+     * @param size        size of data to write
+     * @return Instance ready to write to the created Inbox file
+     * @throws IllegalStateException when inboxApi is not initialized or there's no connection
+     * @throws PrivmxException       if there is an error while creating Inbox file metadata
+     * @throws NativeException       if there is an unknown error while creating inbox file metadata
+     */
+    public static InboxFileStreamWriter createFile(
+            InboxApi api,
+            byte[] publicMeta,
+            byte[] privateMeta,
+            long size
+    ) throws PrivmxException, NativeException, IllegalStateException {
+        if (api == null) throw new NullPointerException("api cannot be null");
+        return new InboxFileStreamWriter(
+                api.createFileHandle(publicMeta, privateMeta, size),
+                api
+        );
+    }
+
+    /**
+     * Writes data to Inbox file.
+     *
+     * @param data data to write (the recommended size of data chunk is {@link InboxFileStream#OPTIMAL_SEND_SIZE})
+     * @throws PrivmxException       if there is an error while writing chunk
+     * @throws NativeException       if there is an unknown error while writing chunk
+     * @throws IllegalStateException when inboxApi is not initialized or there's no connection
+     * @throws IOException           when {@code this} is closed
+     * @throws PrivmxException       when method encounters an exception
+     * @throws NativeException       when method encounters an unknown exception
+     * @throws IllegalStateException when {@link #inboxApi} is closed
+     */
+    public void write(long inboxHandle, byte[] data) throws PrivmxException, NativeException, IllegalStateException, IOException {
+        if (isClosed()) throw new IOException("File handle is closed");
+        inboxApi.writeToFile(inboxHandle, handle, data);
+        callChunkProcessed((long) data.length);
+    }
+
+    public void writeStream(long inboxHandle, InputStream stream) throws PrivmxException, NativeException, IllegalStateException, IOException {
+        writeStream(inboxHandle, stream, null);
+    }
+
+    public void writeStream(long inboxHandle, InputStream inputStream, StoreFileStream.Controller streamController) throws PrivmxException, NativeException, IllegalStateException, IOException {
+        if (streamController != null) {
+            setProgressListener(streamController);
+        }
+        byte[] chunk = new byte[(int) StoreFileStream.OPTIMAL_SEND_SIZE];
+        int readed;
+        while (true) {
+            if (streamController != null && streamController.isStopped()) {
+                break;
+            }
+            if ((readed = inputStream.read(chunk)) <= 0) {
+                break;
+            }
+            write(inboxHandle, Arrays.copyOf(chunk, readed));
+        }
+    }
+}

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
@@ -105,15 +105,15 @@ public class InboxFileStreamWriter extends InboxFileStream {
             setProgressListener(streamController);
         }
         byte[] chunk = new byte[(int) InboxFileStream.OPTIMAL_SEND_SIZE];
-        int readed;
+        int read;
         while (true) {
             if (streamController != null && streamController.isStopped()) {
                 return;
             }
-            if ((readed = inputStream.read(chunk)) <= 0) {
+            if ((read = inputStream.read(chunk)) <= 0) {
                 return;
             }
-            write(inboxHandle, Arrays.copyOf(chunk, readed));
+            write(inboxHandle, Arrays.copyOf(chunk, read));
         }
     }
 }

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
@@ -82,14 +82,14 @@ public class InboxFileStreamWriter extends InboxFileStream {
         if (streamController != null) {
             setProgressListener(streamController);
         }
-        byte[] chunk = new byte[(int) StoreFileStream.OPTIMAL_SEND_SIZE];
+        byte[] chunk = new byte[(int) InboxFileStream.OPTIMAL_SEND_SIZE];
         int readed;
         while (true) {
             if (streamController != null && streamController.isStopped()) {
-                break;
+                return;
             }
             if ((readed = inputStream.read(chunk)) <= 0) {
-                break;
+                return;
             }
             write(inboxHandle, Arrays.copyOf(chunk, readed));
         }


### PR DESCRIPTION
## Description
Closes #4 

## PrivMX Endpoint Extra

### ADDITIONS
1. New Inbox File Streaming classes:
    - InboxFileStream - Base class for streaming files to Inbox.
    - InboxFileStreamReader - Implements methods that simplify the process of reading files from Inbox and writing to an OutputStream.
    - InboxFileStreamWriter - Implements methods that simplify the process of writing files to Inbox and reading from an InputStream.
2. New Inbox Entry Streaming classes: 
    - InboxEntryStream - Streamlines the creation and sending of Inbox entries, supporting optional file attachments with parallel file uploads for enhanced performance.