### PR TITLE
docs: exceptions for inbox methods

### DIFF
--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
@@ -72,9 +72,9 @@ public class InboxEntryStream {
      * @param entryStreamListener the listener for stream state changes
      * @param data                entry data to send
      * @return instance of {@link InboxEntryStream} prepared for streaming
-     * @throws PrivmxException       when method encounters an exception during creating handles for Inbox or file
-     * @throws NativeException       when method encounters an unknown exception during creating handles for Inbox or file
-     * @throws IllegalStateException when {@link IllegalStateException} was thrown during creating handles for Inbox or file
+     * @throws PrivmxException       when method encounters an exception while creating handles for Inbox or file
+     * @throws NativeException       when method encounters an unknown exception while creating handles for Inbox or file
+     * @throws IllegalStateException when {@link IllegalStateException} was thrown while creating handles for Inbox or file
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -96,9 +96,9 @@ public class InboxEntryStream {
      * @param entryStreamListener the listener for stream state changes
      * @param filesConfig         information about each entry's file to send
      * @return instance of {@link InboxEntryStream} prepared for streaming
-     * @throws PrivmxException       when method encounters an exception during creating handles for Inbox or file
-     * @throws NativeException       when method encounters an unknown exception during creating handles for Inbox or file
-     * @throws IllegalStateException when {@link IllegalStateException} was thrown during creating handles for Inbox or file
+     * @throws PrivmxException       when method encounters an exception while creating handles for Inbox or file
+     * @throws NativeException       when method encounters an unknown exception while creating handles for Inbox or file
+     * @throws IllegalStateException when {@link IllegalStateException} was thrown while creating handles for Inbox or file
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -122,9 +122,9 @@ public class InboxEntryStream {
      * @param data                entry data to send
      * @param filesConfig         information about each entry's file to send
      * @return instance of {@link InboxEntryStream} prepared for streaming
-     * @throws PrivmxException       when method encounters an exception during creating handles for Inbox or file
-     * @throws NativeException       when method encounters an unknown exception during creating handles for Inbox or file
-     * @throws IllegalStateException when {@link IllegalStateException} was thrown during creating handles for Inbox or file
+     * @throws PrivmxException       when method encounters an exception while creating handles for Inbox or file
+     * @throws NativeException       when method encounters an unknown exception while creating handles for Inbox or file
+     * @throws IllegalStateException when {@link IllegalStateException} was thrown while creating handles for Inbox or file
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -151,9 +151,9 @@ public class InboxEntryStream {
      * @param filesConfig         information about each entry's file to send
      * @param userPrivKey         sender's private key which can be used later to encrypt data for that sender
      * @return instance of {@link InboxEntryStream} prepared for streaming
-     * @throws PrivmxException       when method encounters an exception during creating handles for Inbox or file
-     * @throws NativeException       when method encounters an unknown exception during creating handles for Inbox or file
-     * @throws IllegalStateException when {@link IllegalStateException} was thrown during creating handles for Inbox or file
+     * @throws PrivmxException       when method encounters an exception while creating handles for Inbox or file
+     * @throws NativeException       when method encounters an unknown exception while creating handles for Inbox or file
+     * @throws IllegalStateException when {@link IllegalStateException} was thrown while creating handles for Inbox or file
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
@@ -72,6 +72,9 @@ public class InboxEntryStream {
      * @param entryStreamListener the listener for stream state changes
      * @param data                entry data to send
      * @return instance of {@link InboxEntryStream} prepared for streaming
+     * @throws PrivmxException       when method encounters an exception during creating handles for Inbox or file
+     * @throws NativeException       when method encounters an unknown exception during creating handles for Inbox or file
+     * @throws IllegalStateException when {@link IllegalStateException} was thrown during creating handles for Inbox or file
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -93,6 +96,9 @@ public class InboxEntryStream {
      * @param entryStreamListener the listener for stream state changes
      * @param filesConfig         information about each entry's file to send
      * @return instance of {@link InboxEntryStream} prepared for streaming
+     * @throws PrivmxException       when method encounters an exception during creating handles for Inbox or file
+     * @throws NativeException       when method encounters an unknown exception during creating handles for Inbox or file
+     * @throws IllegalStateException when {@link IllegalStateException} was thrown during creating handles for Inbox or file
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -116,6 +122,9 @@ public class InboxEntryStream {
      * @param data                entry data to send
      * @param filesConfig         information about each entry's file to send
      * @return instance of {@link InboxEntryStream} prepared for streaming
+     * @throws PrivmxException       when method encounters an exception during creating handles for Inbox or file
+     * @throws NativeException       when method encounters an unknown exception during creating handles for Inbox or file
+     * @throws IllegalStateException when {@link IllegalStateException} was thrown during creating handles for Inbox or file
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -142,6 +151,9 @@ public class InboxEntryStream {
      * @param filesConfig         information about each entry's file to send
      * @param userPrivKey         sender's private key which can be used later to encrypt data for that sender
      * @return instance of {@link InboxEntryStream} prepared for streaming
+     * @throws PrivmxException       when method encounters an exception during creating handles for Inbox or file
+     * @throws NativeException       when method encounters an unknown exception during creating handles for Inbox or file
+     * @throws IllegalStateException when {@link IllegalStateException} was thrown during creating handles for Inbox or file
      */
     public static InboxEntryStream prepareEntry(
             InboxApi inboxApi,
@@ -324,7 +336,7 @@ public class InboxEntryStream {
      *
      * @throws PrivmxException       when method encounters an exception while calling {@link InboxApi#sendEntry} method
      * @throws NativeException       when method encounters an unknown exception while calling {@link InboxApi#sendEntry} method
-     * @throws IllegalStateException if the stream is not in the {@link State#FILES_SENT} state
+     * @throws IllegalStateException if the stream is not in the {@link State#FILES_SENT} state or {@link InboxApi#sendEntry} thrown {@link IllegalStateException}
      */
     public synchronized void sendEntry() throws PrivmxException, NativeException, IllegalStateException {
         if (streamState != State.FILES_SENT) {

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxFileStream/InboxFileStreamWriter.java
@@ -61,13 +61,10 @@ public class InboxFileStreamWriter extends InboxFileStream {
      *
      * @param inboxHandle the handle of the Inbox to write to
      * @param data        data to write (the recommended size of data chunk is {@link InboxFileStream#OPTIMAL_SEND_SIZE})
-     * @throws PrivmxException       if there is an error while writing chunk
-     * @throws NativeException       if there is an unknown error while writing chunk
-     * @throws IllegalStateException when inboxApi is not initialized or there's no connection
-     * @throws IOException           when {@code this} is closed
      * @throws PrivmxException       when method encounters an exception while executing {@link InboxApi#writeToFile}
      * @throws NativeException       when method encounters an unknown exception while executing {@link InboxApi#writeToFile}
      * @throws IllegalStateException when {@link #inboxApi} is closed
+     * @throws IOException           when {@code this} is closed
      */
     public void write(long inboxHandle, byte[] data) throws PrivmxException, NativeException, IllegalStateException, IOException {
         if (isClosed()) throw new IOException("File handle is closed");
@@ -83,7 +80,7 @@ public class InboxFileStreamWriter extends InboxFileStream {
      * @throws PrivmxException       when method encounters an exception while executing {@link InboxApi#writeToFile}
      * @throws NativeException       when method encounters an unknown exception while executing {@link InboxApi#writeToFile}
      * @throws IllegalStateException when {@link #inboxApi} is closed
-     * @throws IOException           when {@link InputStream#read} thrown exception
+     * @throws IOException           when {@link InputStream#read} thrown exception or {@code this} is closed
      */
     public void writeStream(long inboxHandle, InputStream inputStream) throws PrivmxException, NativeException, IllegalStateException, IOException {
         writeStream(inboxHandle, inputStream, null);
@@ -98,7 +95,7 @@ public class InboxFileStreamWriter extends InboxFileStream {
      * @throws PrivmxException       when method encounters an exception while executing {@link InboxApi#writeToFile}
      * @throws NativeException       when method encounters an unknown exception while executing {@link InboxApi#writeToFile}
      * @throws IllegalStateException when {@link #inboxApi} is closed
-     * @throws IOException           when {@link InputStream#read} thrown exception
+     * @throws IOException           when {@link InputStream#read} thrown exception or {@code this} is closed
      */
     public void writeStream(long inboxHandle, InputStream inputStream, StoreFileStream.Controller streamController) throws PrivmxException, NativeException, IllegalStateException, IOException {
         if (streamController != null) {

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
@@ -614,6 +614,11 @@ public class InboxApi implements AutoCloseable {
      */
     public native void unsubscribeFromEntryEvents(String inboxId) throws PrivmxException, NativeException, IllegalStateException;
 
+    /**
+     * Frees memory.
+     *
+     * @throws Exception when instance is currently closed.
+     */
     @Override
     public void close() throws Exception {
         deinit();

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
@@ -20,6 +20,8 @@ import com.simplito.java.privmx_endpoint.model.PagingList;
 import com.simplito.java.privmx_endpoint.model.UserWithPubKey;
 import com.simplito.java.privmx_endpoint.model.events.InboxDeletedEventData;
 import com.simplito.java.privmx_endpoint.model.events.InboxEntryDeletedEventData;
+import com.simplito.java.privmx_endpoint.model.exceptions.NativeException;
+import com.simplito.java.privmx_endpoint.model.exceptions.PrivmxException;
 import com.simplito.java.privmx_endpoint.modules.core.Connection;
 import com.simplito.java.privmx_endpoint.modules.store.StoreApi;
 import com.simplito.java.privmx_endpoint.modules.thread.ThreadApi;
@@ -103,11 +105,20 @@ public class InboxApi implements AutoCloseable {
      * @param publicMeta  public (unencrypted) metadata
      * @param privateMeta private (encrypted) metadata
      * @return ID of the created Inbox
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      * @event type: inboxCreated
      * channel: inbox
      * payload: {@link Inbox}
      */
-    public String createInbox(String contextId, List<UserWithPubKey> users, List<UserWithPubKey> managers, byte[] publicMeta, byte[] privateMeta) {
+    public String createInbox(
+            String contextId,
+            List<UserWithPubKey> users,
+            List<UserWithPubKey> managers,
+            byte[] publicMeta,
+            byte[] privateMeta
+    ) throws PrivmxException, NativeException, IllegalStateException {
         return createInbox(contextId, users, managers, publicMeta, privateMeta, null);
     }
 
@@ -122,11 +133,21 @@ public class InboxApi implements AutoCloseable {
      * @param privateMeta private (encrypted) metadata
      * @param filesConfig overrides default file configuration
      * @return ID of the created Inbox
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      * @event type: inboxCreated
      * channel: inbox
      * payload: {@link Inbox}
      */
-    public String createInbox(String contextId, List<UserWithPubKey> users, List<UserWithPubKey> managers, byte[] publicMeta, byte[] privateMeta, FilesConfig filesConfig) {
+    public String createInbox(
+            String contextId,
+            List<UserWithPubKey> users,
+            List<UserWithPubKey> managers,
+            byte[] publicMeta,
+            byte[] privateMeta,
+            FilesConfig filesConfig
+    ) throws PrivmxException, NativeException, IllegalStateException {
         return createInbox(contextId, users, managers, publicMeta, privateMeta, filesConfig, null);
     }
 
@@ -142,11 +163,22 @@ public class InboxApi implements AutoCloseable {
      * @param filesConfig overrides default file configuration
      * @param policies    additional container access policies
      * @return ID of the created Inbox
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      * @event type: inboxCreated
      * channel: inbox
      * payload: {@link Inbox}
      */
-    public native String createInbox(String contextId, List<UserWithPubKey> users, List<UserWithPubKey> managers, byte[] publicMeta, byte[] privateMeta, FilesConfig filesConfig, ContainerPolicyWithoutItem policies);
+    public native String createInbox(
+            String contextId,
+            List<UserWithPubKey> users,
+            List<UserWithPubKey> managers,
+            byte[] publicMeta,
+            byte[] privateMeta,
+            FilesConfig filesConfig,
+            ContainerPolicyWithoutItem policies
+    ) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Updates an existing Inbox.
@@ -160,11 +192,23 @@ public class InboxApi implements AutoCloseable {
      * @param filesConfig struct to override default files configuration
      * @param version     current version of the updated Inbox
      * @param force       force update (without checking version)
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      * @event type: inboxUpdated
      * channel: inbox
      * payload: {@link Inbox}
      */
-    public void updateInbox(String inboxId, List<UserWithPubKey> users, List<UserWithPubKey> managers, byte[] publicMeta, byte[] privateMeta, FilesConfig filesConfig, long version, boolean force) {
+    public void updateInbox(
+            String inboxId,
+            List<UserWithPubKey> users,
+            List<UserWithPubKey> managers,
+            byte[] publicMeta,
+            byte[] privateMeta,
+            FilesConfig filesConfig,
+            long version,
+            boolean force
+    ) throws PrivmxException, NativeException, IllegalStateException {
         updateInbox(inboxId, users, managers, publicMeta, privateMeta, filesConfig, version, force, true);
     }
 
@@ -181,11 +225,24 @@ public class InboxApi implements AutoCloseable {
      * @param version             current version of the updated Inbox
      * @param force               force update (without checking version)
      * @param forceGenerateNewKey force to regenerate a key for the Inbox
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      * @event type: inboxUpdated
      * channel: inbox
      * payload: {@link Inbox}
      */
-    public void updateInbox(String inboxId, List<UserWithPubKey> users, List<UserWithPubKey> managers, byte[] publicMeta, byte[] privateMeta, FilesConfig filesConfig, long version, boolean force, boolean forceGenerateNewKey) {
+    public void updateInbox(
+            String inboxId,
+            List<UserWithPubKey> users,
+            List<UserWithPubKey> managers,
+            byte[] publicMeta,
+            byte[] privateMeta,
+            FilesConfig filesConfig,
+            long version,
+            boolean force,
+            boolean forceGenerateNewKey
+    ) throws PrivmxException, NativeException, IllegalStateException {
         this.updateInbox(inboxId, users, managers, publicMeta, privateMeta, filesConfig, version, force, forceGenerateNewKey, null);
     }
 
@@ -203,6 +260,9 @@ public class InboxApi implements AutoCloseable {
      * @param force               force update (without checking version)
      * @param forceGenerateNewKey force to regenerate a key for the Inbox
      * @param policies            additional container access policies
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      * @event type: inboxUpdated
      * channel: inbox
      * payload: {@link Inbox}
@@ -218,15 +278,18 @@ public class InboxApi implements AutoCloseable {
             boolean force,
             boolean forceGenerateNewKey,
             ContainerPolicyWithoutItem policies
-    );
+    ) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Gets a single Inbox by given Inbox ID.
      *
      * @param inboxId ID of the Inbox to get
      * @return Information about the Inbox
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native Inbox getInbox(String inboxId);
+    public native Inbox getInbox(String inboxId) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Gets a list of Inboxes in given Context.
@@ -236,8 +299,16 @@ public class InboxApi implements AutoCloseable {
      * @param limit     limit of elements to return for query
      * @param sortOrder order of elements in result ("asc" for ascending, "desc" for descending)
      * @return list of Inboxes
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public PagingList<Inbox> listInboxes(String contextId, long skip, long limit, String sortOrder) {
+    public PagingList<Inbox> listInboxes(
+            String contextId,
+            long skip,
+            long limit,
+            String sortOrder
+    ) throws PrivmxException, NativeException, IllegalStateException {
         return listInboxes(contextId, skip, limit, sortOrder, null);
     }
 
@@ -250,8 +321,17 @@ public class InboxApi implements AutoCloseable {
      * @param sortOrder order of elements in result ("asc" for ascending, "desc" for descending)
      * @param lastId    ID of the element from which query results should start
      * @return list of Inboxes
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native PagingList<Inbox> listInboxes(String contextId, long skip, long limit, String sortOrder, String lastId);
+    public native PagingList<Inbox> listInboxes(
+            String contextId,
+            long skip,
+            long limit,
+            String sortOrder,
+            String lastId
+    ) throws PrivmxException, NativeException, IllegalStateException;
 
 
     /**
@@ -260,18 +340,24 @@ public class InboxApi implements AutoCloseable {
      *
      * @param inboxId ID of the Inbox to get
      * @return Public accessible information about the Inbox
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native InboxPublicView getInboxPublicView(String inboxId);
+    public native InboxPublicView getInboxPublicView(String inboxId) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Deletes an Inbox by given Inbox ID.
      *
      * @param inboxId ID of the Inbox to delete
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      * @event type: inboxDeleted
      * channel: inbox
      * payload: {@link InboxDeletedEventData}
      */
-    public native void deleteInbox(String inboxId);
+    public native void deleteInbox(String inboxId) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Prepares a request to send data to an Inbox.
@@ -280,8 +366,11 @@ public class InboxApi implements AutoCloseable {
      * @param inboxId ID of the Inbox to which the request applies
      * @param data    entry data to send
      * @return Inbox handle
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public Long /*inboxHandle*/ prepareEntry(String inboxId, byte[] data) {
+    public Long prepareEntry(String inboxId, byte[] data) throws PrivmxException, NativeException, IllegalStateException {
         return prepareEntry(inboxId, data, Collections.emptyList(), null);
     }
 
@@ -293,8 +382,15 @@ public class InboxApi implements AutoCloseable {
      * @param data             entry data to send
      * @param inboxFileHandles optional list of file handles that will be sent with the request
      * @return Inbox handle
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public Long /*inboxHandle*/ prepareEntry(String inboxId, byte[] data, List<Long> inboxFileHandles) {
+    public Long prepareEntry(
+            String inboxId,
+            byte[] data,
+            List<Long> inboxFileHandles
+    ) throws PrivmxException, NativeException, IllegalStateException {
         return prepareEntry(inboxId, data, inboxFileHandles, null);
     }
 
@@ -307,27 +403,41 @@ public class InboxApi implements AutoCloseable {
      * @param inboxFileHandles optional list of file handles that will be sent with the request
      * @param userPrivKey      optional sender's private key which can be used later to encrypt data for that sender
      * @return Inbox handle
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native Long /*inboxHandle*/ prepareEntry(String inboxId, byte[] data, List<Long> inboxFileHandles, String userPrivKey);
+    public native Long prepareEntry(
+            String inboxId,
+            byte[] data,
+            List<Long> inboxFileHandles,
+            String userPrivKey
+    ) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Sends data to an Inbox.
      * You do not have to be logged in to call this function.
      *
      * @param inboxHandle ID of the Inbox to which the request applies
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      * @event type: inboxEntryCreated
      * channel: inbox/&lt;inboxId&gt;/entries
      * payload: {@link InboxEntry}
      */
-    public native void sendEntry(long inboxHandle);
+    public native void sendEntry(long inboxHandle) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Gets an entry from an Inbox.
      *
      * @param inboxEntryId ID of an entry to read from the Inbox
      * @return Data of the selected entry stored in the Inbox
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native InboxEntry readEntry(String inboxEntryId);
+    public native InboxEntry readEntry(String inboxEntryId) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Gets list of entries in given Inbox.
@@ -337,8 +447,16 @@ public class InboxApi implements AutoCloseable {
      * @param limit     limit of elements to return for query
      * @param sortOrder order of elements in result ("asc" for ascending, "desc" for descending)
      * @return list of entries
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public PagingList<InboxEntry> listEntries(String inboxId, long skip, long limit, String sortOrder) {
+    public PagingList<InboxEntry> listEntries(
+            String inboxId,
+            long skip,
+            long limit,
+            String sortOrder
+    ) throws PrivmxException, NativeException, IllegalStateException {
         return listEntries(inboxId, skip, limit, sortOrder, null);
     }
 
@@ -351,18 +469,30 @@ public class InboxApi implements AutoCloseable {
      * @param sortOrder order of elements in result ("asc" for ascending, "desc" for descending)
      * @param lastId    ID of the element from which query results should start
      * @return list of entries
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native PagingList<InboxEntry> listEntries(String inboxId, long skip, long limit, String sortOrder, String lastId);
+    public native PagingList<InboxEntry> listEntries(
+            String inboxId,
+            long skip,
+            long limit,
+            String sortOrder,
+            String lastId
+    ) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Deletes an entry from an Inbox.
      *
      * @param inboxEntryId ID of an entry to delete
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      * @event type: inboxEntryDeleted
      * channel: inbox/&lt;inboxId&gt;/entries
      * payload: {@link InboxEntryDeletedEventData}
      */
-    public native void deleteEntry(String inboxEntryId);
+    public native void deleteEntry(String inboxEntryId) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Creates a file handle to send a file to an Inbox.
@@ -372,8 +502,15 @@ public class InboxApi implements AutoCloseable {
      * @param privateMeta private file's metadata
      * @param fileSize    size of the file to send
      * @return File handle
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native Long /*inboxFileHandle*/ createFileHandle(byte[] publicMeta, byte[] privateMeta, long fileSize);
+    public native Long /*inboxFileHandle*/ createFileHandle(
+            byte[] publicMeta,
+            byte[] privateMeta,
+            long fileSize
+    ) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Sends a file's data chunk to an Inbox.
@@ -383,8 +520,15 @@ public class InboxApi implements AutoCloseable {
      * @param inboxHandle     ID of the Inbox to which the request applies
      * @param inboxFileHandle handle to the file where the uploaded chunk belongs
      * @param dataChunk       file chunk to send
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native void writeToFile(long inboxHandle, long inboxFileHandle, byte[] dataChunk);
+    public native void writeToFile(
+            long inboxHandle,
+            long inboxFileHandle,
+            byte[] dataChunk
+    ) throws PrivmxException, NativeException, IllegalStateException;
 
 
     /**
@@ -392,8 +536,11 @@ public class InboxApi implements AutoCloseable {
      *
      * @param fileId ID of the file to read
      * @return Handle to read file data
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native Long openFile(String fileId);
+    public native Long openFile(String fileId) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Reads file data.
@@ -401,48 +548,71 @@ public class InboxApi implements AutoCloseable {
      * @param fileHandle handle to the file
      * @param length     size of data to read
      * @return File data chunk
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native byte[] readFromFile(long fileHandle, long length);
+    public native byte[] readFromFile(long fileHandle, long length) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Moves file's read cursor.
      *
      * @param fileHandle handle to the file
      * @param position   sets new cursor position
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native void seekInFile(long fileHandle, long position);
+    public native void seekInFile(long fileHandle, long position) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Closes a file by given handle.
      *
      * @param fileHandle handle to the file
      * @return ID of closed file
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native String closeFile(long fileHandle);
+    public native String closeFile(long fileHandle) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Subscribes for the Inbox module main events.
+     *
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native void subscribeForInboxEvents();
+    public native void subscribeForInboxEvents() throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Subscribes for the Inbox module main events.
+     *
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native void unsubscribeFromInboxEvents();
+    public native void unsubscribeFromInboxEvents() throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Subscribes for events in given Inbox.
      *
      * @param inboxId ID of the Inbox to subscribe
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native void subscribeForEntryEvents(String inboxId);
+    public native void subscribeForEntryEvents(String inboxId) throws PrivmxException, NativeException, IllegalStateException;
 
     /**
      * Unsubscribes from events in given Inbox.
      *
      * @param inboxId ID of the Inbox to unsubscribe
+     * @throws PrivmxException       thrown when method encounters an exception.
+     * @throws NativeException       thrown when method encounters an unknown exception.
+     * @throws IllegalStateException thrown when instance is closed.
      */
-    public native void unsubscribeFromEntryEvents(String inboxId);
+    public native void unsubscribeFromEntryEvents(String inboxId) throws PrivmxException, NativeException, IllegalStateException;
 
     @Override
     public void close() throws Exception {


### PR DESCRIPTION
# Description
Closes #11 

## PrivMX Endpoint
1. Add block throws in documentation for InboxApi methods.
2. Add documentation for close method in InboxApi class.

## PrivMX Endpoint Extra
1. Add information about exceptions in InboxEntryStream and InboxFileStreamWritter classes.