### PR TITLE
[FIX]: make policy builders methods public

### DIFF
--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/policies/builders/ContainerPolicyBuilder.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/policies/builders/ContainerPolicyBuilder.java
@@ -72,7 +72,7 @@ public class ContainerPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ContainerPolicyBuilder} instance to allow for method chaining.
      */
-    ContainerPolicyBuilder setGet(ContainerPolicyValue policyValue) {
+    public ContainerPolicyBuilder setGet(ContainerPolicyValue policyValue) {
         this.get = policyValue.value;
         return this;
     }
@@ -83,7 +83,7 @@ public class ContainerPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ContainerPolicyBuilder} instance to allow for method chaining.
      */
-    ContainerPolicyBuilder setUpdate(ContainerPolicyValue policyValue) {
+    public ContainerPolicyBuilder setUpdate(ContainerPolicyValue policyValue) {
         this.update = policyValue.value;
         return this;
     }
@@ -94,7 +94,7 @@ public class ContainerPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ContainerPolicyBuilder} instance to allow for method chaining.
      */
-    ContainerPolicyBuilder setDelete(ContainerPolicyValue policyValue) {
+    public ContainerPolicyBuilder setDelete(ContainerPolicyValue policyValue) {
         this.delete = policyValue.value;
         return this;
     }
@@ -105,7 +105,7 @@ public class ContainerPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ContainerPolicyBuilder} instance to allow for method chaining.
      */
-    ContainerPolicyBuilder setUpdatePolicy(ContainerPolicyValue policyValue) {
+    public ContainerPolicyBuilder setUpdatePolicy(ContainerPolicyValue policyValue) {
         this.updatePolicy = policyValue.value;
         return this;
     }
@@ -116,7 +116,7 @@ public class ContainerPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ContainerPolicyBuilder} instance to allow for method chaining.
      */
-    ContainerPolicyBuilder setUpdaterCanBeRemovedFromManagers(SpecialPolicyValue policyValue) {
+    public ContainerPolicyBuilder setUpdaterCanBeRemovedFromManagers(SpecialPolicyValue policyValue) {
         this.updaterCanBeRemovedFromManagers = policyValue.value;
         return this;
     }
@@ -127,7 +127,7 @@ public class ContainerPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ContainerPolicyBuilder} instance to allow for method chaining.
      */
-    ContainerPolicyBuilder setOwnerCanBeRemovedFromManagers(SpecialPolicyValue policyValue) {
+    public ContainerPolicyBuilder setOwnerCanBeRemovedFromManagers(SpecialPolicyValue policyValue) {
         this.ownerCanBeRemovedFromManagers = policyValue.value;
         return this;
     }
@@ -138,7 +138,7 @@ public class ContainerPolicyBuilder {
      * @param item policy value to set
      * @return {@link ContainerPolicyBuilder} instance to allow for method chaining.
      */
-    ContainerPolicyBuilder setItem(ItemPolicy item) {
+    public ContainerPolicyBuilder setItem(ItemPolicy item) {
         this.item = item;
         return this;
     }
@@ -148,7 +148,7 @@ public class ContainerPolicyBuilder {
      *
      * @return new {@link ContainerPolicyWithoutItem} instance created from this builder policies.
      */
-    ContainerPolicyWithoutItem buildWithoutItem() {
+    public ContainerPolicyWithoutItem buildWithoutItem() {
         return new ContainerPolicyWithoutItem(
                 get,
                 update,
@@ -164,7 +164,7 @@ public class ContainerPolicyBuilder {
      *
      * @return new {@link ContainerPolicy} instance created from this builder policies.
      */
-    ContainerPolicy build() {
+    public ContainerPolicy build() {
         return new ContainerPolicy(
                 get,
                 update,

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/policies/builders/ItemPolicyBuilder.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/policies/builders/ItemPolicyBuilder.java
@@ -51,7 +51,7 @@ public class ItemPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ItemPolicyBuilder} instance to allow for method chaining.
      */
-    ItemPolicyBuilder setGet(ItemPolicyValue policyValue) {
+    public ItemPolicyBuilder setGet(ItemPolicyValue policyValue) {
         this.get = policyValue.value;
         return this;
     }
@@ -62,7 +62,7 @@ public class ItemPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ItemPolicyBuilder} instance to allow for method chaining.
      */
-    ItemPolicyBuilder setListMy(ItemPolicyValue policyValue) {
+    public ItemPolicyBuilder setListMy(ItemPolicyValue policyValue) {
         this.listMy = policyValue.value;
         return this;
     }
@@ -73,7 +73,7 @@ public class ItemPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ItemPolicyBuilder} instance to allow for method chaining.
      */
-    ItemPolicyBuilder setListAll(ItemPolicyValue policyValue) {
+    public ItemPolicyBuilder setListAll(ItemPolicyValue policyValue) {
 
         this.listAll = policyValue.value;
         return this;
@@ -85,7 +85,7 @@ public class ItemPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ItemPolicyBuilder} instance to allow for method chaining.
      */
-    ItemPolicyBuilder setCreate(ItemPolicyValue policyValue) {
+    public ItemPolicyBuilder setCreate(ItemPolicyValue policyValue) {
         this.create = policyValue.value;
         return this;
     }
@@ -96,7 +96,7 @@ public class ItemPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ItemPolicyBuilder} instance to allow for method chaining.
      */
-    ItemPolicyBuilder setUpdate(ItemPolicyValue policyValue) {
+    public ItemPolicyBuilder setUpdate(ItemPolicyValue policyValue) {
         this.update = policyValue.value;
         return this;
     }
@@ -107,7 +107,7 @@ public class ItemPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ItemPolicyBuilder} instance to allow for method chaining.
      */
-    ItemPolicyBuilder setDelete(ItemPolicyValue policyValue) {
+    public ItemPolicyBuilder setDelete(ItemPolicyValue policyValue) {
         this.delete = policyValue.value;
         return this;
     }
@@ -117,7 +117,7 @@ public class ItemPolicyBuilder {
      *
      * @return new {@link ItemPolicy} instance created from this builder policies.
      */
-    ItemPolicy build() {
+    public ItemPolicy build() {
         return new ItemPolicy(
                 get,
                 listMy,


### PR DESCRIPTION
## CHANGES

### PrivMX Endpoint Extra:

#### MODIFICATIONS
Methods changed to public:
1. In ContainerPolicyBuilder: 
- setGet,
- setUpdate
- setDelete
- setUpdatePolicy
- setUpdaterCanBeRemovedFromManagers
- setOwnerCanBeRemovedFromManagers
- setItem
- buildWithoutItem 
- build

2. In ItemPolicyBuilder:
- setGet
- setListMy
- setListAll
- setCreate
- setUpdate
- setDelete
- build
