### PR TITLE
[FIX]: restore constructors without policies

### DIFF
--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Inbox.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Inbox.java
@@ -141,4 +141,42 @@ public class Inbox {
         this.policy = policy;
         this.statusCode = statusCode;
     }
+
+
+    /**
+     * Creates instance of {@code Inbox}.
+     * Constructor without policy parameter (default null)
+     *
+     * @param inboxId              ID of the Inbox.
+     * @param contextId            ID of the Context.
+     * @param createDate           Inbox creation timestamp.
+     * @param creator              ID of the user who created the Inbox.
+     * @param lastModificationDate Inbox last modification timestamp.
+     * @param lastModifier         ID of the user who last modified the Inbox.
+     * @param users                List of users (their IDs) with access to the Inbox.
+     * @param managers             List of users (their IDs) with management rights.
+     * @param version              Version number (changes on updates).
+     * @param publicMeta           Inbox public metadata.
+     * @param privateMeta          Inbox private metadata.
+     * @param filesConfig          Inbox files configuration.
+     * @param statusCode           Status code of retrieval and decryption of the {@code Inbox}.
+     */
+    @Deprecated
+    public Inbox(
+            String inboxId,
+            String contextId,
+            Long createDate,
+            String creator,
+            Long lastModificationDate,
+            String lastModifier,
+            List<String> users,
+            List<String> managers,
+            Long version,
+            byte[] publicMeta,
+            byte[] privateMeta,
+            FilesConfig filesConfig,
+            Long statusCode
+    ) {
+        this(inboxId, contextId, createDate, creator, lastModificationDate, lastModifier, users, managers, version, publicMeta, privateMeta, filesConfig, null, statusCode);
+    }
 }

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Inbox.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Inbox.java
@@ -144,8 +144,7 @@ public class Inbox {
 
 
     /**
-     * Creates instance of {@code Inbox}.
-     * Constructor without policy parameter (default null)
+     * Creates instance of {@code Inbox} with null policy value.
      *
      * @param inboxId              ID of the Inbox.
      * @param contextId            ID of the Context.

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Store.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Store.java
@@ -148,4 +148,43 @@ public class Store {
         this.filesCount = filesCount;
         this.statusCode = statusCode;
     }
+
+    /**
+     * Creates instance of {@code Store}.
+     * Constructor without policy parameter (default null)
+     *
+     * @param storeId              ID of the Store.
+     * @param contextId            ID of the Context.
+     * @param createDate           Store creation timestamp.
+     * @param creator              ID of the user who created the Store.
+     * @param lastModificationDate Store last modification timestamp.
+     * @param lastFileDate         Timestamp of the last created file.
+     * @param lastModifier         ID of the user who last modified the Store.
+     * @param users                List of users (their IDs) with access to the Store.
+     * @param managers             List of users (their IDs) with management rights.
+     * @param version              Version number (changes on updates).
+     * @param publicMeta           Store's public metadata.
+     * @param privateMeta          Store's private metadata.
+     * @param filesCount           Total number of files in the Store.
+     * @param statusCode           Status code of retrieval and decryption of the {@code Store}.
+     */
+    @Deprecated
+    public Store(
+            String storeId,
+            String contextId,
+            Long createDate,
+            String creator,
+            Long lastModificationDate,
+            Long lastFileDate,
+            String lastModifier,
+            List<String> users,
+            List<String> managers,
+            Long version,
+            byte[] publicMeta,
+            byte[] privateMeta,
+            Long filesCount,
+            Long statusCode
+    ) {
+        this(storeId, contextId, createDate, creator, lastModificationDate, lastFileDate, lastModifier, users, managers, version, publicMeta, privateMeta, null, filesCount, statusCode);
+    }
 }

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Store.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Store.java
@@ -150,8 +150,7 @@ public class Store {
     }
 
     /**
-     * Creates instance of {@code Store}.
-     * Constructor without policy parameter (default null)
+     * Creates instance of {@code Store} with null policy value.
      *
      * @param storeId              ID of the Store.
      * @param contextId            ID of the Context.

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Thread.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Thread.java
@@ -150,4 +150,43 @@ public class Thread {
         this.messagesCount = messagesCount;
         this.statusCode = statusCode;
     }
+
+    /**
+     * Creates instance of {@code Thread}.
+     * Constructor without policy parameter (default null)
+     *
+     * @param contextId            ID of the Context.
+     * @param threadId             ID of the Thread.
+     * @param createDate           Thread creation timestamp.
+     * @param creator              ID of the user who created the Thread.
+     * @param lastModificationDate Thread last modification timestamp.
+     * @param lastModifier         ID of the user who last modified the Thread.
+     * @param users                List of users (their IDs) with access to the Thread.
+     * @param managers             List of users (their IDs) with management rights.
+     * @param version              Version number (changes on updates).
+     * @param lastMsgDate          Timestamp of the last posted message.
+     * @param publicMeta           Total number of messages in the Thread.
+     * @param privateMeta          Thread's public metadata.
+     * @param messagesCount        Thread's private metadata.
+     * @param statusCode           Status code of retrieval and decryption of the {@code Thread}.
+     */
+    @Deprecated
+    public Thread(
+            String contextId,
+            String threadId,
+            Long createDate,
+            String creator,
+            Long lastModificationDate,
+            String lastModifier,
+            List<String> users,
+            List<String> managers,
+            Long version,
+            Long lastMsgDate,
+            byte[] publicMeta,
+            byte[] privateMeta,
+            Long messagesCount,
+            Long statusCode
+    ) {
+        this(contextId, threadId, createDate, creator, lastModificationDate, lastModifier, users, managers, version, lastMsgDate, publicMeta, privateMeta, null, messagesCount, statusCode);
+    }
 }

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Thread.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/Thread.java
@@ -152,8 +152,7 @@ public class Thread {
     }
 
     /**
-     * Creates instance of {@code Thread}.
-     * Constructor without policy parameter (default null)
+     * Creates instance of {@code Thread} with null policy value.
      *
      * @param contextId            ID of the Context.
      * @param threadId             ID of the Thread.


### PR DESCRIPTION
# Description

Model Thread/Store/Inbox in version 2.1.0 defines field policy. Now these classes contain two constructors:
- with policy parameter
- without policy parameter - which calls new constructor with null policy

## PrivMX Endpoint
### ADDITIONS
New constructors in **Thread**, **Store** and **Inbox** classes without policy field (default policy value is null).
