### PR TITLE
[FIX]: change parameter forceGenerateNewKey default value.

### DIFF
--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
@@ -210,7 +210,7 @@ public class InboxApi implements AutoCloseable {
             long version,
             boolean force
     ) throws PrivmxException, NativeException, IllegalStateException {
-        updateInbox(inboxId, users, managers, publicMeta, privateMeta, filesConfig, version, force, true);
+        updateInbox(inboxId, users, managers, publicMeta, privateMeta, filesConfig, version, force, false);
     }
 
     /**

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/store/StoreApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/store/StoreApi.java
@@ -116,7 +116,7 @@ public class StoreApi implements AutoCloseable {
      * payload: {@link Store}
      */
     public void updateStore(String storeId, List<UserWithPubKey> users, List<UserWithPubKey> managers, byte[] publicMeta, byte[] privateMeta, long version, boolean force) throws PrivmxException, NativeException, IllegalStateException {
-        updateStore(storeId, users, managers, publicMeta, privateMeta, version, force, true);
+        updateStore(storeId, users, managers, publicMeta, privateMeta, version, force, false);
     }
 
     /**

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/thread/ThreadApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/thread/ThreadApi.java
@@ -116,7 +116,7 @@ public class ThreadApi implements AutoCloseable {
      * payload: {@link Thread}
      */
     public void updateThread(String threadId, List<UserWithPubKey> users, List<UserWithPubKey> managers, byte[] publicMeta, byte[] privateMeta, long version, boolean force) throws PrivmxException, NativeException, IllegalStateException {
-        updateThread(threadId, users, managers, publicMeta, privateMeta, version, force, true);
+        updateThread(threadId, users, managers, publicMeta, privateMeta, version, force, false);
     }
 
     /**


### PR DESCRIPTION
# Description
Closes #21 

# Changes
## PrivMX Endpoint
### MODIFICATIONS
Now update methods for Thread/Store/Inbox call updates with `forceGenerateNewKey` default value set to `true`.