### PR TITLE
[FIX]: Change Policy Types In ItemPolicyBuilder Class

### DIFF
--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/policies/ItemPolicyValues.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/policies/ItemPolicyValues.java
@@ -22,6 +22,11 @@ public class ItemPolicyValues {
     public static final ItemPolicyValue DEFAULT = new ItemPolicyValue("default");
 
     /**
+     * Uses the value inherited from the Context.
+     */
+    public static final ItemPolicyValue INHERIT = new ItemPolicyValue("inherit");
+
+    /**
      * Prevents actions from being performed on item.
      */
     public static final ItemPolicyValue NONE = new ItemPolicyValue("none");

--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/policies/builders/ItemPolicyBuilder.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/policies/builders/ItemPolicyBuilder.java
@@ -12,6 +12,7 @@
 package com.simplito.java.privmx_endpoint_extra.policies.builders;
 
 import com.simplito.java.privmx_endpoint.model.ItemPolicy;
+import com.simplito.java.privmx_endpoint_extra.policies.ContainerPolicyValue;
 import com.simplito.java.privmx_endpoint_extra.policies.ItemPolicyValue;
 
 /**
@@ -62,7 +63,7 @@ public class ItemPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ItemPolicyBuilder} instance to allow for method chaining.
      */
-    public ItemPolicyBuilder setListMy(ItemPolicyValue policyValue) {
+    public ItemPolicyBuilder setListMy(ContainerPolicyValue policyValue) {
         this.listMy = policyValue.value;
         return this;
     }
@@ -73,7 +74,7 @@ public class ItemPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ItemPolicyBuilder} instance to allow for method chaining.
      */
-    public ItemPolicyBuilder setListAll(ItemPolicyValue policyValue) {
+    public ItemPolicyBuilder setListAll(ContainerPolicyValue policyValue) {
 
         this.listAll = policyValue.value;
         return this;
@@ -85,7 +86,7 @@ public class ItemPolicyBuilder {
      * @param policyValue policy value to set
      * @return {@link ItemPolicyBuilder} instance to allow for method chaining.
      */
-    public ItemPolicyBuilder setCreate(ItemPolicyValue policyValue) {
+    public ItemPolicyBuilder setCreate(ContainerPolicyValue policyValue) {
         this.create = policyValue.value;
         return this;
     }


### PR DESCRIPTION
## Description
Closes #23 

## Changes
### PrivMX Endpoint Extra
#### ADDITIONS
1. New static field `INHERIT` in `ItemPolicyValues` class
#### MODIFICATIONS
Change parameter `policyValue` type from `ItemPolicyValue` to `ContainerPolicyValue` in `ItemPolicyBuilder`'s class methods:
- `setListMy`
- `setListAll`
- `setCreate`
