### PR TITLE
fix: Make InboxEntryStream.onError method synchronized and no call cancel() method

### DIFF
--- a/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
+++ b/privmx-endpoint-extra/src/main/java/com/simplito/java/privmx_endpoint_extra/inboxEntryStream/InboxEntryStream.java
@@ -277,8 +277,7 @@ public class InboxEntryStream {
         }
     }
 
-    private void onError(Throwable t) {
-        cancel();
+    private synchronized void onError(Throwable t) {
         stopFileStreams();
         closeFileHandles();
         updateState(State.ERROR);


### PR DESCRIPTION
# Description
Closes #25 
Fix closing InboxEntryStream after error during entry creation process. 
