### PR TITLE
[docs]: update fileHandle parameter description in InboxApi.writeToFile method

### DIFF
--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
@@ -518,7 +518,7 @@ public class InboxApi implements AutoCloseable {
      * To send the entire file - divide it into pieces of the desired size and call the function for each fragment.
      * You do not have to be logged in to call this function.
      *
-     * @param inboxHandle     ID of the Inbox to which the request applies
+     * @param inboxHandle     handle to the prepared Inbox entry
      * @param inboxFileHandle handle to the file where the uploaded chunk belongs
      * @param dataChunk       file chunk to send
      * @throws PrivmxException       thrown when method encounters an exception.


### PR DESCRIPTION
Update fileHandle parameter description in InboxApi.writeToFile method from `ID of the Inbox to which the request applies` to ` Handle to the prepared Inbox entry`.