### PR TITLE
chore: implement native libs distribution by maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ This library implements models, exception catching, and the following modules:
 1. Add `mavenCentral()` repository to your `settings.gradle`:
 
 ```groovy
+pluginManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
@@ -90,6 +96,14 @@ dependencies {
     implementation("com.simplito.java:privmx-endpoint-extra:$privmxLibVersion")
     //implementation("com.simplito.java:privmx-endpoint:$privmxLibVersion")  //for base Java library 
     //implementation("com.simplito.java:privmx-endpoint-android:$privmxLibVersion") //for Android Java library 
+}
+```
+
+3. Add PrivMX plugin to `build.gradle`:
+
+```groovy
+plugins {
+    id "com.simplito.privmx-endpoint-install-native" version "2.0.0"
 }
 ```
 

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/LibLoader.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/LibLoader.java
@@ -91,8 +91,8 @@ public class LibLoader {
         );
     }
 
-    static private boolean extractLibraries() {
-        if (libsDir != null) return true;
+    static private void extractLibraries() {
+        if (libsDir != null) return;
         String librariesDirectoryPath = System.getProperty("java.library.path");
         if (Pattern.compile(":?\\.(?::?|$)").matcher(librariesDirectoryPath).find()) {
             librariesDirectoryPath = System.getProperty("user.dir");
@@ -102,20 +102,17 @@ public class LibLoader {
         File librariesDirectory = new File(librariesDirectoryPath);
 
         if (!librariesDirectory.exists() && !librariesDirectory.mkdirs()) {
-            return false;
-        } else {
-            libsDir = librariesDirectory;
-            libsDir.deleteOnExit();
-            try {
-                getBinaryResourcePaths(
-                        getPlatformLibsResourceDirPath()
-                ).forEach(LibLoader::extractResource);
-            } catch (Exception e) {
-                System.out.println(e.getMessage());
-            }
+            return;
         }
 
-        return true;
+        libsDir = librariesDirectory;
+        try {
+            getBinaryResourcePaths(
+                    getPlatformLibsResourceDirPath()
+            ).forEach(LibLoader::extractResource);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
     }
 }
 

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/LibLoader.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/LibLoader.java
@@ -91,7 +91,7 @@ public class LibLoader {
         );
     }
 
-    static private boolean extractLibraries() throws UnsatisfiedLinkError {
+    static private boolean extractLibraries() {
         if (libsDir != null) return true;
         String librariesDirectoryPath = System.getProperty("java.library.path");
         if (Pattern.compile(":?\\.(?::?|$)").matcher(librariesDirectoryPath).find()) {
@@ -110,8 +110,8 @@ public class LibLoader {
                 getBinaryResourcePaths(
                         getPlatformLibsResourceDirPath()
                 ).forEach(LibLoader::extractResource);
-            } catch (IOException e) {
-                throw new UnsatisfiedLinkError("Cannot read binary resources");
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
             }
         }
 

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/LibLoader.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/LibLoader.java
@@ -1,0 +1,121 @@
+//
+// PrivMX Endpoint Java.
+// Copyright © 2025 Simplito sp. z o.o.
+//
+// This file is part of the PrivMX Platform (https://privmx.dev).
+// This software is Licensed under the MIT License.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.simplito.java.privmx_endpoint;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class LibLoader {
+    static private File libsDir = null;
+
+    static {
+        try {
+            Class.forName("android.os.Bundle");
+        } catch (Throwable e) {
+            extractLibraries();
+        }
+    }
+
+    public static void loadPrivmxLibraries() {
+        System.loadLibrary("privmx-endpoint-java");
+    }
+
+    private static String getPlatformLibsResourceDirPath() throws UnsatisfiedLinkError {
+        String os = System.getProperty("os.name");
+        String arch = System.getProperty("os.arch");
+        if (os == null) throw new NoSuchFieldError("Cannot found os name");
+        if (arch == null) throw new NoSuchFieldError("Cannot found arch name");
+        os = os.toLowerCase();
+        if (os.startsWith("mac os")) {
+            if (arch.equalsIgnoreCase("aarch64")) return "/lib/Darwin/arm64";
+        }
+        throw new UnsatisfiedLinkError("os: " + os + ", arch: " + arch + " is not supported.");
+    }
+
+
+    private static void extractResource(String resourcePath) throws UnsatisfiedLinkError {
+        File localLibFile = new File(libsDir, resourcePath.substring(resourcePath.lastIndexOf("/")));
+        try (InputStream is = LibLoader.class.getResourceAsStream(resourcePath)) {
+            if (is == null) throw new UnsatisfiedLinkError("Cannot found resource " + resourcePath);
+            if (localLibFile.exists()) localLibFile.delete();
+            if (localLibFile.createNewFile()) {
+                byte[] data = new byte[1024];
+                int read;
+                try (OutputStream oS = new FileOutputStream(localLibFile)) {
+                    while ((read = is.read(data)) >= 0) {
+                        oS.write(Arrays.copyOf(data, read));
+                    }
+                } catch (IOException e) {
+                    throw new UnsatisfiedLinkError("Cannot extract PrivMX binaries");
+                }
+            }
+        } catch (IOException | NullPointerException e) {
+            localLibFile.delete();
+            throw new UnsatisfiedLinkError("Cannot extract PrivMX binaries");
+        }
+    }
+
+    private static Stream<String> getBinaryResourcePaths(String platformLibsResourceDirPath) throws IOException {
+        String fileNames = new BufferedReader(
+                new InputStreamReader(
+                        Objects.requireNonNull(
+                                LibLoader.class.getResourceAsStream(
+                                        platformLibsResourceDirPath + "/" + "fileNames.txt"
+                                )
+                        )
+                )
+        ).readLine();
+
+        return Arrays.stream(
+                fileNames.split(";")
+        ).map(
+                fileName -> platformLibsResourceDirPath + "/" + fileName
+        );
+    }
+
+    static private boolean extractLibraries() throws UnsatisfiedLinkError {
+        if (libsDir != null) return true;
+        String librariesDirectoryPath = System.getProperty("java.library.path");
+        if (Pattern.compile(":?\\.(?::?|$)").matcher(librariesDirectoryPath).find()) {
+            librariesDirectoryPath = System.getProperty("user.dir");
+        } else {
+            librariesDirectoryPath = librariesDirectoryPath.substring(librariesDirectoryPath.lastIndexOf(":") + 1);
+        }
+        File librariesDirectory = new File(librariesDirectoryPath);
+
+        if (!librariesDirectory.exists() && !librariesDirectory.mkdirs()) {
+            return false;
+        } else {
+            libsDir = librariesDirectory;
+            libsDir.deleteOnExit();
+            try {
+                getBinaryResourcePaths(
+                        getPlatformLibsResourceDirPath()
+                ).forEach(LibLoader::extractResource);
+            } catch (IOException e) {
+                throw new UnsatisfiedLinkError("Cannot read binary resources");
+            }
+        }
+
+        return true;
+    }
+}
+

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/LibLoader.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/LibLoader.java
@@ -41,8 +41,8 @@ public class LibLoader {
     private static String getPlatformLibsResourceDirPath() throws UnsatisfiedLinkError {
         String os = System.getProperty("os.name");
         String arch = System.getProperty("os.arch");
-        if (os == null) throw new NoSuchFieldError("Cannot found os name");
-        if (arch == null) throw new NoSuchFieldError("Cannot found arch name");
+        if (os == null) throw new NoSuchFieldError("Cannot find os name");
+        if (arch == null) throw new NoSuchFieldError("Cannot find arch name");
         os = os.toLowerCase();
         if (os.startsWith("mac os")) {
             if (arch.equalsIgnoreCase("aarch64")) return "/lib/Darwin/arm64";
@@ -54,7 +54,7 @@ public class LibLoader {
     private static void extractResource(String resourcePath) throws UnsatisfiedLinkError {
         File localLibFile = new File(libsDir, resourcePath.substring(resourcePath.lastIndexOf("/")));
         try (InputStream is = LibLoader.class.getResourceAsStream(resourcePath)) {
-            if (is == null) throw new UnsatisfiedLinkError("Cannot found resource " + resourcePath);
+            if (is == null) throw new UnsatisfiedLinkError("Cannot find resource " + resourcePath);
             if (localLibFile.exists()) localLibFile.delete();
             if (localLibFile.createNewFile()) {
                 byte[] data = new byte[1024];

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/Connection.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/Connection.java
@@ -1,6 +1,6 @@
 //
 // PrivMX Endpoint Java.
-// Copyright © 2024 Simplito sp. z o.o.
+// Copyright © 2025 Simplito sp. z o.o.
 //
 // This file is part of the PrivMX Platform (https://privmx.dev).
 // This software is Licensed under the MIT License.
@@ -11,6 +11,7 @@
 
 package com.simplito.java.privmx_endpoint.modules.core;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
 import com.simplito.java.privmx_endpoint.model.Context;
 import com.simplito.java.privmx_endpoint.model.PKIVerificationOptions;
 import com.simplito.java.privmx_endpoint.model.PagingList;
@@ -27,7 +28,7 @@ import java.util.List;
  */
 public class Connection implements AutoCloseable {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     private final Long api;

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/utils/Base32.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/utils/Base32.java
@@ -11,9 +11,11 @@
 
 package com.simplito.java.privmx_endpoint.modules.core.utils;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
+
 public class Base32 {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     /**

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/utils/Base64.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/utils/Base64.java
@@ -11,9 +11,11 @@
 
 package com.simplito.java.privmx_endpoint.modules.core.utils;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
+
 public class Base64 {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     /**

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/utils/Hex.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/utils/Hex.java
@@ -11,9 +11,11 @@
 
 package com.simplito.java.privmx_endpoint.modules.core.utils;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
+
 public class Hex {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     public Hex() {

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/utils/Utils.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/core/utils/Utils.java
@@ -11,11 +11,13 @@
 
 package com.simplito.java.privmx_endpoint.modules.core.utils;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
+
 import java.util.List;
 
 public class Utils {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     /**

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/crypto/CryptoApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/crypto/CryptoApi.java
@@ -1,6 +1,6 @@
 //
 // PrivMX Endpoint Java.
-// Copyright © 2024 Simplito sp. z o.o.
+// Copyright © 2025 Simplito sp. z o.o.
 //
 // This file is part of the PrivMX Platform (https://privmx.dev).
 // This software is Licensed under the MIT License.
@@ -11,6 +11,7 @@
 
 package com.simplito.java.privmx_endpoint.modules.crypto;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
 import com.simplito.java.privmx_endpoint.model.BIP39;
 import com.simplito.java.privmx_endpoint.model.exceptions.NativeException;
 import com.simplito.java.privmx_endpoint.model.exceptions.PrivmxException;
@@ -22,7 +23,7 @@ import com.simplito.java.privmx_endpoint.model.exceptions.PrivmxException;
  */
 public class CryptoApi implements AutoCloseable {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     @SuppressWarnings("FieldCanBeLocal")

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/crypto/ExtKey.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/crypto/ExtKey.java
@@ -11,6 +11,7 @@
 
 package com.simplito.java.privmx_endpoint.modules.crypto;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
 import com.simplito.java.privmx_endpoint.model.exceptions.NativeException;
 import com.simplito.java.privmx_endpoint.model.exceptions.PrivmxException;
 
@@ -21,7 +22,7 @@ import com.simplito.java.privmx_endpoint.model.exceptions.PrivmxException;
  */
 public class ExtKey implements AutoCloseable {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     private final Long key;

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/event/EventApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/event/EventApi.java
@@ -11,6 +11,7 @@
 
 package com.simplito.java.privmx_endpoint.modules.event;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
 import com.simplito.java.privmx_endpoint.model.UserWithPubKey;
 import com.simplito.java.privmx_endpoint.model.exceptions.NativeException;
 import com.simplito.java.privmx_endpoint.model.exceptions.PrivmxException;
@@ -26,7 +27,7 @@ import java.util.Objects;
  */
 public class EventApi implements AutoCloseable {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     private final Long api;

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
@@ -1,6 +1,6 @@
 //
 // PrivMX Endpoint Java.
-// Copyright © 2024 Simplito sp. z o.o.
+// Copyright © 2025 Simplito sp. z o.o.
 //
 // This file is part of the PrivMX Platform (https://privmx.dev).
 // This software is Licensed under the MIT License.
@@ -11,6 +11,7 @@
 
 package com.simplito.java.privmx_endpoint.modules.inbox;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
 import com.simplito.java.privmx_endpoint.model.ContainerPolicyWithoutItem;
 import com.simplito.java.privmx_endpoint.model.FilesConfig;
 import com.simplito.java.privmx_endpoint.model.Inbox;
@@ -38,7 +39,7 @@ import java.util.Optional;
  */
 public class InboxApi implements AutoCloseable {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     @SuppressWarnings("FieldCanBeLocal")

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/store/StoreApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/store/StoreApi.java
@@ -1,6 +1,6 @@
 //
 // PrivMX Endpoint Java.
-// Copyright © 2024 Simplito sp. z o.o.
+// Copyright © 2025 Simplito sp. z o.o.
 //
 // This file is part of the PrivMX Platform (https://privmx.dev).
 // This software is Licensed under the MIT License.
@@ -11,6 +11,7 @@
 
 package com.simplito.java.privmx_endpoint.modules.store;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
 import com.simplito.java.privmx_endpoint.model.ContainerPolicy;
 import com.simplito.java.privmx_endpoint.model.File;
 import com.simplito.java.privmx_endpoint.model.PagingList;
@@ -33,7 +34,7 @@ import java.util.Objects;
  */
 public class StoreApi implements AutoCloseable {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     @SuppressWarnings("FieldCanBeLocal")

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/thread/ThreadApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/thread/ThreadApi.java
@@ -1,6 +1,6 @@
 //
 // PrivMX Endpoint Java.
-// Copyright © 2024 Simplito sp. z o.o.
+// Copyright © 2025 Simplito sp. z o.o.
 //
 // This file is part of the PrivMX Platform (https://privmx.dev).
 // This software is Licensed under the MIT License.
@@ -11,6 +11,7 @@
 
 package com.simplito.java.privmx_endpoint.modules.thread;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
 import com.simplito.java.privmx_endpoint.model.ContainerPolicy;
 import com.simplito.java.privmx_endpoint.model.Message;
 import com.simplito.java.privmx_endpoint.model.PagingList;
@@ -33,7 +34,7 @@ import java.util.Objects;
  */
 public class ThreadApi implements AutoCloseable {
     static {
-        System.loadLibrary("privmx-endpoint-java");
+        LibLoader.loadPrivmxLibraries();
     }
 
     @SuppressWarnings("FieldCanBeLocal")


### PR DESCRIPTION
## Description
Implementation of new libs distribution method. Binaries are packed to desktop and android jars and attached by plugin to runtime configuration. In runtime:
* desktop - unpack binaries to working directory or last path from `java.library.path` property before loading them
* android - only load libraries