### PR TITLE
[FIX]: Change the order of arguments in a UserStatusChange constructor

### DIFF
--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/UserStatusChange.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/model/UserStatusChange.java
@@ -17,11 +17,11 @@ public class UserStatusChange {
     /**
      * Creates instance of {@code UserStatusChange}
      *
-     * @param timestamp User status change action, which can be "login" or "logout"
      * @param action    Timestamp of the change
+     * @param timestamp User status change action, which can be "login" or "logout"
      */
-    public UserStatusChange(Long timestamp, String action) {
-        this.timestamp = timestamp;
+    public UserStatusChange(String action, Long timestamp) {
         this.action = action;
+        this.timestamp = timestamp;
     }
 }


### PR DESCRIPTION
## Description
Change the order of args in a UserStatusChange constructor to match the jni constructor.