### PR TITLE
[FIX]: Remove errors from CollectionItemChange event parser

### DIFF
--- a/privmx-endpoint/src/main/cpp/model_native_initializers.cpp
+++ b/privmx-endpoint/src/main/cpp/model_native_initializers.cpp
@@ -194,8 +194,8 @@ namespace privmx {
                     collectionItemChangeCls,
                     "<init>",
                     "("
-                    "Ljava/lang/String;Ljava/lang/String;"  // itemId
-                    "Ljava/lang/String;Ljava/lang/String;"  // action
+                    "Ljava/lang/String;"  // itemId
+                    "Ljava/lang/String;"  // action
                     ")V"
             );
             return ctx->NewObject(


### PR DESCRIPTION
## Description
Fix parser for CollectionItemChange event. A piece of code was accidentally duplicated.