### PR TITLE
[FEAT]: Add turn credentials

### DIFF
--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusConnection.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusConnection.java
@@ -17,7 +17,6 @@ import java.util.function.BiConsumer;
 public class JanusConnection {
     protected final PeerConnection peerConnection;
     protected final PeerConnectionFactory peerConnectionFactory;
-    private List<PeerConnection.IceServer> configuration;
     protected PmxKeyStore keyStore;
     public final ConnectionType connectionType;
     private long sessionId = -1L;
@@ -29,17 +28,6 @@ public class JanusConnection {
             ConnectionType connectionType,
             TrackObserver trackObserver,
             BiConsumer<Long,String> onTrickle
-    ) {
-        this(pcFactory, keyStore, connectionType, trackObserver, onTrickle, Collections.emptyList());
-    }
-
-    public JanusConnection(
-            PeerConnectionFactory pcFactory,
-            PmxKeyStore keyStore,
-            ConnectionType connectionType,
-            TrackObserver trackObserver,
-            BiConsumer<Long, String> onTrickle,
-            List<PeerConnection.IceServer> configuration
     ) {
         this.peerConnectionFactory = pcFactory;
         this.connectionType = connectionType;
@@ -66,7 +54,6 @@ public class JanusConnection {
                     }
                 }
         );
-        this.configuration = configuration;
         this.peerConnection = createPeerConnection(pcObserver);
     }
 
@@ -101,7 +88,7 @@ public class JanusConnection {
     //TODO: We need method to pass framecryptorOptions and TrackObserver
     private PeerConnection createPeerConnection(PcObserver pcObserver) {
         return peerConnectionFactory.createPeerConnection(
-                new PeerConnection.RTCConfiguration(configuration),
+                new PeerConnection.RTCConfiguration(Collections.emptyList()),
                 pcObserver
         );
     }
@@ -136,7 +123,6 @@ public class JanusConnection {
     }
 
     public void setRTCConfiguration(List<PeerConnection.IceServer> configuration) {
-        this.configuration = configuration;
         this.peerConnection.setConfiguration(new PeerConnection.RTCConfiguration(configuration));
     }
 }

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusConnection.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusConnection.java
@@ -10,12 +10,14 @@ import org.webrtc.PmxKeyStore;
 import org.webrtc.SessionDescription;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
 public class JanusConnection {
     protected final PeerConnection peerConnection;
     protected final PeerConnectionFactory peerConnectionFactory;
+    private final List<PeerConnection.IceServer> configuration;
     protected PmxKeyStore keyStore;
     public final ConnectionType connectionType;
     private long sessionId = -1L;
@@ -27,6 +29,17 @@ public class JanusConnection {
             ConnectionType connectionType,
             TrackObserver trackObserver,
             BiConsumer<Long,String> onTrickle
+    ) {
+        this(pcFactory, keyStore, connectionType, trackObserver, onTrickle, Collections.emptyList());
+    }
+
+    public JanusConnection(
+            PeerConnectionFactory pcFactory,
+            PmxKeyStore keyStore,
+            ConnectionType connectionType,
+            TrackObserver trackObserver,
+            BiConsumer<Long, String> onTrickle,
+            List<PeerConnection.IceServer> configuration
     ) {
         this.peerConnectionFactory = pcFactory;
         this.connectionType = connectionType;
@@ -53,6 +66,7 @@ public class JanusConnection {
                     }
                 }
         );
+        this.configuration = configuration;
         this.peerConnection = createPeerConnection(pcObserver);
     }
 
@@ -87,7 +101,7 @@ public class JanusConnection {
     //TODO: We need method to pass framecryptorOptions and TrackObserver
     private PeerConnection createPeerConnection(PcObserver pcObserver) {
         return peerConnectionFactory.createPeerConnection(
-                new PeerConnection.RTCConfiguration(Collections.emptyList()),
+                new PeerConnection.RTCConfiguration(configuration),
                 pcObserver
         );
     }

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusConnection.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusConnection.java
@@ -17,7 +17,7 @@ import java.util.function.BiConsumer;
 public class JanusConnection {
     protected final PeerConnection peerConnection;
     protected final PeerConnectionFactory peerConnectionFactory;
-    private final List<PeerConnection.IceServer> configuration;
+    private List<PeerConnection.IceServer> configuration;
     protected PmxKeyStore keyStore;
     public final ConnectionType connectionType;
     private long sessionId = -1L;
@@ -133,5 +133,10 @@ public class JanusConnection {
         if(peerConnection.connectionState() != PeerConnection.PeerConnectionState.CLOSED) {
             peerConnection.dispose();
         }
+    }
+
+    public void setRTCConfiguration(List<PeerConnection.IceServer> configuration) {
+        this.configuration = configuration;
+        this.peerConnection.setConfiguration(new PeerConnection.RTCConfiguration(configuration));
     }
 }

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusPublisher.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusPublisher.java
@@ -7,7 +7,6 @@ import com.simplito.java.privmx_endpoint.model.ConnectionType;
 import com.simplito.java.privmx_endpoint.model.VideoTrackInfo;
 
 import org.webrtc.MediaConstraints;
-import org.webrtc.PeerConnection;
 import org.webrtc.PeerConnectionFactory;
 import org.webrtc.PmxFrameCryptor;
 import org.webrtc.PmxFrameCryptorFactory;
@@ -17,7 +16,6 @@ import org.webrtc.SessionDescription;
 import org.webrtc.VideoCapturer;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
@@ -32,10 +30,9 @@ public class JanusPublisher extends JanusConnection{
             PeerConnectionFactory pcFactory,
             PmxKeyStore keyStore,
             TrackObserver observer,
-            BiConsumer<Long, String> onTrickle,
-            List<PeerConnection.IceServer> configuration
+            BiConsumer<Long, String> onTrickle
     ) {
-        super(pcFactory, keyStore, ConnectionType.Publisher, observer, onTrickle, configuration);
+        super(pcFactory, keyStore, ConnectionType.Publisher, observer, onTrickle);
     }
 
     public void addAudioTrack(org.webrtc.AudioTrack audioTrack) {

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusPublisher.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusPublisher.java
@@ -7,6 +7,7 @@ import com.simplito.java.privmx_endpoint.model.ConnectionType;
 import com.simplito.java.privmx_endpoint.model.VideoTrackInfo;
 
 import org.webrtc.MediaConstraints;
+import org.webrtc.PeerConnection;
 import org.webrtc.PeerConnectionFactory;
 import org.webrtc.PmxFrameCryptor;
 import org.webrtc.PmxFrameCryptorFactory;
@@ -16,6 +17,7 @@ import org.webrtc.SessionDescription;
 import org.webrtc.VideoCapturer;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
@@ -26,9 +28,14 @@ public class JanusPublisher extends JanusConnection{
     //TODO: Add videoCapturer to VideoTrackInfo
     public final Map<String, VideoCapturer> videoCapturers = new HashMap<>();
 
-
-    public JanusPublisher(PeerConnectionFactory pcFactory, PmxKeyStore keyStore, TrackObserver observer, BiConsumer<Long,String> onTrickle) {
-        super(pcFactory, keyStore, ConnectionType.Publisher, observer, onTrickle);
+    public JanusPublisher(
+            PeerConnectionFactory pcFactory,
+            PmxKeyStore keyStore,
+            TrackObserver observer,
+            BiConsumer<Long, String> onTrickle,
+            List<PeerConnection.IceServer> configuration
+    ) {
+        super(pcFactory, keyStore, ConnectionType.Publisher, observer, onTrickle, configuration);
     }
 
     public void addAudioTrack(org.webrtc.AudioTrack audioTrack) {
@@ -82,7 +89,7 @@ public class JanusPublisher extends JanusConnection{
     }
 
     public void addVideoTrack(org.webrtc.VideoTrack videoTrack) {
-        addVideoTrack(videoTrack,null);
+        addVideoTrack(videoTrack, null);
     }
 
     public void removeAudioTrack(String id) {

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusSubscriber.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusSubscriber.java
@@ -3,16 +3,24 @@ package com.simplito.java.privmx_endpoint.modules.stream;
 import com.simplito.java.privmx_endpoint.model.ConnectionType;
 
 import org.webrtc.MediaConstraints;
+import org.webrtc.PeerConnection;
 import org.webrtc.PeerConnectionFactory;
 import org.webrtc.PmxKeyStore;
 import org.webrtc.SessionDescription;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
-public class JanusSubscriber extends JanusConnection{
-    public JanusSubscriber(PeerConnectionFactory pcFactory, PmxKeyStore keyStore, TrackObserver observer, BiConsumer<Long,String> onTrickle) {
-        super(pcFactory, keyStore, ConnectionType.Publisher, observer, onTrickle);
+public class JanusSubscriber extends JanusConnection {
+    public JanusSubscriber(
+            PeerConnectionFactory pcFactory,
+            PmxKeyStore keyStore,
+            TrackObserver observer,
+            BiConsumer<Long, String> onTrickle,
+            List<PeerConnection.IceServer> configuration
+    ) {
+        super(pcFactory, keyStore, ConnectionType.Publisher, observer, onTrickle, configuration);
     }
 
     public String createAnswer(String offerSdp){

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusSubscriber.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/JanusSubscriber.java
@@ -17,10 +17,9 @@ public class JanusSubscriber extends JanusConnection {
             PeerConnectionFactory pcFactory,
             PmxKeyStore keyStore,
             TrackObserver observer,
-            BiConsumer<Long, String> onTrickle,
-            List<PeerConnection.IceServer> configuration
+            BiConsumer<Long, String> onTrickle
     ) {
-        super(pcFactory, keyStore, ConnectionType.Publisher, observer, onTrickle, configuration);
+        super(pcFactory, keyStore, ConnectionType.Publisher, observer, onTrickle);
     }
 
     public String createAnswer(String offerSdp){

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/PeerConnectionManager.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/PeerConnectionManager.java
@@ -20,7 +20,6 @@ class PeerConnectionManager {
     private final Map<Long, String> sessionHandles = new HashMap<>();
     protected final PeerConnectionFactory pcFactory;
     private final BiConsumer<Long,String> onTrickle;
-    private List<PeerConnection.IceServer> configuration;
 
     PeerConnectionManager(
             PeerConnectionFactory pcFactory,
@@ -31,9 +30,9 @@ class PeerConnectionManager {
     }
 
     @NonNull
-    public RoomJanusSession createSession(@NonNull String streamRoomId, List<PeerConnection.IceServer> configuration) {
+    public RoomJanusSession createSession(@NonNull String streamRoomId) {
         return Optional.ofNullable(
-                sessions.putIfAbsent(streamRoomId, new RoomJanusSession(streamRoomId, pcFactory, onTrickle, configuration))
+                sessions.putIfAbsent(streamRoomId, new RoomJanusSession(streamRoomId, pcFactory, onTrickle))
         ).orElse(Objects.requireNonNull(sessions.get(streamRoomId)));
     }
 

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/PeerConnectionManager.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/PeerConnectionManager.java
@@ -5,20 +5,22 @@ import androidx.annotation.Nullable;
 
 import com.simplito.java.privmx_endpoint.model.stream.StreamHandle;
 
+import org.webrtc.PeerConnection;
 import org.webrtc.PeerConnectionFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 
 class PeerConnectionManager {
     private final Map<String, RoomJanusSession> sessions = new HashMap<>();
     private final Map<Long, String> sessionHandles = new HashMap<>();
     protected final PeerConnectionFactory pcFactory;
     private final BiConsumer<Long,String> onTrickle;
+    private List<PeerConnection.IceServer> configuration;
 
     PeerConnectionManager(
             PeerConnectionFactory pcFactory,
@@ -29,9 +31,9 @@ class PeerConnectionManager {
     }
 
     @NonNull
-    public RoomJanusSession createSession(@NonNull String streamRoomId) {
+    public RoomJanusSession createSession(@NonNull String streamRoomId, List<PeerConnection.IceServer> configuration) {
         return Optional.ofNullable(
-                sessions.putIfAbsent(streamRoomId, new RoomJanusSession(streamRoomId, pcFactory, onTrickle))
+                sessions.putIfAbsent(streamRoomId, new RoomJanusSession(streamRoomId, pcFactory, onTrickle, configuration))
         ).orElse(Objects.requireNonNull(sessions.get(streamRoomId)));
     }
 

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/RoomJanusSession.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/RoomJanusSession.java
@@ -36,20 +36,17 @@ public class RoomJanusSession {
     private final BiConsumer<Long,String> onTrickle;
     private final Map<String, TrackObserver> trackObserversByStreamId = new HashMap<>();
     private final TrackObserver trackObserver = new TrackObserverImpl();
-    private List<PeerConnection.IceServer> configuration = Collections.emptyList();
 
     //TODO: Add error listener for catch errors from webrtcInterface
     public RoomJanusSession(
             @NonNull String roomId,
             @NonNull PeerConnectionFactory pcFactory,
-            BiConsumer<Long,String> onTrickle,
-            List<PeerConnection.IceServer> configuration
+            BiConsumer<Long,String> onTrickle
     ) {
         this.pcFactory = pcFactory;
         this.roomID = roomId;
         this.keyStore = PmxFrameCryptorFactory.createPmxKeyStore();
         this.onTrickle = onTrickle;
-        this.configuration = configuration;
     }
 
     @Nullable
@@ -68,10 +65,10 @@ public class RoomJanusSession {
 
     public synchronized void createSubscriber(TrackObserver observer) {
         if (subscriber == null) {
-            subscriber = new JanusSubscriber(pcFactory, keyStore, observer, onTrickle, configuration);
+            subscriber = new JanusSubscriber(pcFactory, keyStore, observer, onTrickle);
         } else if (subscriber.isEnded()) {
             subscriber.close();
-            subscriber = new JanusSubscriber(pcFactory, keyStore, observer, onTrickle, configuration);
+            subscriber = new JanusSubscriber(pcFactory, keyStore, observer, onTrickle);
         } else {
             throw new IllegalStateException("Subscriber is currently active.");
         }
@@ -83,10 +80,10 @@ public class RoomJanusSession {
 
     public synchronized void createPublisher(TrackObserver observer) {
         if (publisher == null) {
-            publisher = new JanusPublisher(pcFactory, keyStore, observer, onTrickle, configuration);
+            publisher = new JanusPublisher(pcFactory, keyStore, observer, onTrickle);
         }else if (publisher.isEnded()) {
             publisher.close();
-            publisher = new JanusPublisher(pcFactory, keyStore, observer, onTrickle, configuration);
+            publisher = new JanusPublisher(pcFactory, keyStore, observer, onTrickle);
         }else{
             throw new IllegalStateException("Publisher is currently active.");
         }

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/RoomJanusSession.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/RoomJanusSession.java
@@ -3,7 +3,6 @@ package com.simplito.java.privmx_endpoint.modules.stream;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-
 import com.simplito.java.privmx_endpoint.model.stream.Key;
 import com.simplito.java.privmx_endpoint.model.stream.KeyType;
 import org.webrtc.MediaStreamTrack;
@@ -37,13 +36,20 @@ public class RoomJanusSession {
     private final BiConsumer<Long,String> onTrickle;
     private final Map<String, TrackObserver> trackObserversByStreamId = new HashMap<>();
     private final TrackObserver trackObserver = new TrackObserverImpl();
+    private List<PeerConnection.IceServer> configuration = Collections.emptyList();
 
     //TODO: Add error listener for catch errors from webrtcInterface
-    public RoomJanusSession(@NonNull String roomId, @NonNull PeerConnectionFactory pcFactory, BiConsumer<Long,String> onTrickle) {
+    public RoomJanusSession(
+            @NonNull String roomId,
+            @NonNull PeerConnectionFactory pcFactory,
+            BiConsumer<Long,String> onTrickle,
+            List<PeerConnection.IceServer> configuration
+    ) {
         this.pcFactory = pcFactory;
         this.roomID = roomId;
         this.keyStore = PmxFrameCryptorFactory.createPmxKeyStore();
         this.onTrickle = onTrickle;
+        this.configuration = configuration;
     }
 
     @Nullable
@@ -62,11 +68,11 @@ public class RoomJanusSession {
 
     public synchronized void createSubscriber(TrackObserver observer) {
         if (subscriber == null) {
-            subscriber = new JanusSubscriber(pcFactory, keyStore, observer, onTrickle);
-        }else if (subscriber.isEnded()) {
+            subscriber = new JanusSubscriber(pcFactory, keyStore, observer, onTrickle, configuration);
+        } else if (subscriber.isEnded()) {
             subscriber.close();
-            subscriber = new JanusSubscriber(pcFactory, keyStore, observer, onTrickle);
-        }else{
+            subscriber = new JanusSubscriber(pcFactory, keyStore, observer, onTrickle, configuration);
+        } else {
             throw new IllegalStateException("Subscriber is currently active.");
         }
     }
@@ -77,10 +83,10 @@ public class RoomJanusSession {
 
     public synchronized void createPublisher(TrackObserver observer) {
         if (publisher == null) {
-            publisher = new JanusPublisher(pcFactory, keyStore, observer, onTrickle);
+            publisher = new JanusPublisher(pcFactory, keyStore, observer, onTrickle, configuration);
         }else if (publisher.isEnded()) {
             publisher.close();
-            publisher = new JanusPublisher(pcFactory, keyStore, observer, onTrickle);
+            publisher = new JanusPublisher(pcFactory, keyStore, observer, onTrickle, configuration);
         }else{
             throw new IllegalStateException("Publisher is currently active.");
         }

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
@@ -165,14 +165,8 @@ public class StreamApi {
     public void joinStreamRoom(
             String streamRoomId
     ) {
-        List<PeerConnection.IceServer> iceServers = api.getTurnCredentials().stream().map(item -> PeerConnection.IceServer.builder(item.url)
-                .setUsername(item.username)
-                .setPassword(item.password)
-                .createIceServer()
-        ).collect(Collectors.toList());
-
         //TODO: Rollback this change, it is do only for run test
-        RoomJanusSession session = pcManager.createSession(streamRoomId, iceServers);
+        RoomJanusSession session = pcManager.createSession(streamRoomId, getRTCConfiguration());
         api.joinStreamRoom(streamRoomId, session.webrtc);
     }
 
@@ -268,11 +262,13 @@ public class StreamApi {
 
     public StreamPublishResult publishStream(StreamHandle streamHandle) {
         Objects.requireNonNull(streamHandle);
+        setRTCConfiguration(streamHandle, Mode.PUBLISHER);
         return api.publishStream(streamHandle);
     }
 
     public StreamPublishResult updateStream(StreamHandle streamHandle) {
         Objects.requireNonNull(streamHandle);
+        setRTCConfiguration(streamHandle, Mode.PUBLISHER);
         return api.updateStream(streamHandle);
     }
 
@@ -298,6 +294,7 @@ public class StreamApi {
             throw new IllegalStateException("No active session to this Stream Room. Join stream room first");
         try {
             session.createSubscriber();
+            setRTCConfiguration(streamRoomId, Mode.SUBSCRIBER);
         } catch (IllegalStateException ignored) {}
         api.subscribeToRemoteStreams(streamRoomId, subscriptions, options);
     }
@@ -321,6 +318,7 @@ public class StreamApi {
             List<StreamSubscription> subscriptionsToRemove,
             Settings options
     ) {
+        setRTCConfiguration(streamRoomId, Mode.SUBSCRIBER);
         api.modifyRemoteStreamsSubscriptions(
                 streamRoomId,
                 subscriptionsToAdd,
@@ -333,6 +331,7 @@ public class StreamApi {
             String streamRoomId,
             List<StreamSubscription> subscriptionsToRemove
     ) {
+        setRTCConfiguration(streamRoomId, Mode.SUBSCRIBER);
         api.unsubscribeFromRemoteStreams(
                 streamRoomId,
                 subscriptionsToRemove

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
@@ -167,7 +167,7 @@ public class StreamApi {
             String streamRoomId
     ) {
         //TODO: Rollback this change, it is do only for run test
-        RoomJanusSession session = pcManager.createSession(streamRoomId, getRTCConfiguration());
+        RoomJanusSession session = pcManager.createSession(streamRoomId);
         api.joinStreamRoom(streamRoomId, session.webrtc);
     }
 
@@ -263,13 +263,25 @@ public class StreamApi {
 
     public StreamPublishResult publishStream(StreamHandle streamHandle) {
         Objects.requireNonNull(streamHandle);
-        setRTCConfiguration(streamHandle, ConnectionType.Publisher);
+        RoomJanusSession session = pcManager.getSession(streamHandle);
+        if (session == null)
+            throw new IllegalStateException("Stream with this StreamHandle doesn't exist.");
+        JanusPublisher publisher = session.getPublisher();
+        if (publisher == null)
+            throw new IllegalStateException("This StreamHandle has not created companion publisher.");
+        publisher.setRTCConfiguration(getRTCConfiguration());
         return api.publishStream(streamHandle);
     }
 
     public StreamPublishResult updateStream(StreamHandle streamHandle) {
         Objects.requireNonNull(streamHandle);
-        setRTCConfiguration(streamHandle, ConnectionType.Publisher);
+        RoomJanusSession session = pcManager.getSession(streamHandle);
+        if (session == null)
+            throw new IllegalStateException("Stream with this StreamHandle doesn't exist.");
+        JanusPublisher publisher = session.getPublisher();
+        if (publisher == null)
+            throw new IllegalStateException("This StreamHandle has not created companion publisher.");
+        publisher.setRTCConfiguration(getRTCConfiguration());
         return api.updateStream(streamHandle);
     }
 
@@ -295,8 +307,11 @@ public class StreamApi {
             throw new IllegalStateException("No active session to this Stream Room. Join stream room first");
         try {
             session.createSubscriber();
-            setRTCConfiguration(streamRoomId, ConnectionType.Subscriber);
-        } catch (IllegalStateException ignored) {}
+        } catch (IllegalStateException ignored) {
+        }
+        if (session.getSubscriber() == null)
+            throw new IllegalStateException("This streamRoom has not created companion subscriber.");
+        session.getSubscriber().setRTCConfiguration(getRTCConfiguration());
         api.subscribeToRemoteStreams(streamRoomId, subscriptions, options);
     }
 
@@ -319,7 +334,12 @@ public class StreamApi {
             List<StreamSubscription> subscriptionsToRemove,
             Settings options
     ) {
-        setRTCConfiguration(streamRoomId, ConnectionType.Subscriber);
+        RoomJanusSession session = pcManager.getSession(streamRoomId);
+        if (session == null)
+            throw new IllegalStateException("No active session to this Stream Room. Join stream room first");
+        if (session.getSubscriber() == null)
+            throw new IllegalStateException("This streamRoom has not created companion subscriber.");
+        session.getSubscriber().setRTCConfiguration(getRTCConfiguration());
         api.modifyRemoteStreamsSubscriptions(
                 streamRoomId,
                 subscriptionsToAdd,
@@ -332,7 +352,12 @@ public class StreamApi {
             String streamRoomId,
             List<StreamSubscription> subscriptionsToRemove
     ) {
-        setRTCConfiguration(streamRoomId,ConnectionType.Subscriber);
+        RoomJanusSession session = pcManager.getSession(streamRoomId);
+        if (session == null)
+            throw new IllegalStateException("No active session to this Stream Room. Join stream room first");
+        if (session.getSubscriber() == null)
+            throw new IllegalStateException("This streamRoom has not created companion subscriber.");
+        session.getSubscriber().setRTCConfiguration(getRTCConfiguration());
         api.unsubscribeFromRemoteStreams(
                 streamRoomId,
                 subscriptionsToRemove
@@ -371,7 +396,6 @@ public class StreamApi {
         );
     }
 
-    // ----- PRIV
     private List<PeerConnection.IceServer> getRTCConfiguration() {
         return api.getTurnCredentials().stream().map(item ->
                 PeerConnection.IceServer.builder(item.url)
@@ -379,35 +403,5 @@ public class StreamApi {
                         .setPassword(item.password)
                         .createIceServer()
         ).collect(Collectors.toList());
-    }
-
-    private void setRTCConfiguration(Object key, ConnectionType mode) {
-        RoomJanusSession session = key instanceof StreamHandle
-                ? pcManager.getSession((StreamHandle) key)
-                : pcManager.getSession((String) key);
-
-        if (session == null) {
-            throw new IllegalStateException(
-                    "No active session to this Stream Room. Join stream room first"
-            );
-        }
-
-        applyRTCConfiguration(session, mode);
-    }
-
-    private void applyRTCConfiguration(RoomJanusSession session, ConnectionType mode) {
-        switch (mode) {
-            case Publisher:
-                if (session.getPublisher() != null) {
-                    session.getPublisher().setRTCConfiguration(getRTCConfiguration());
-                }
-                break;
-
-            case Subscriber:
-                if (session.getSubscriber() != null) {
-                    session.getSubscriber().setRTCConfiguration(getRTCConfiguration());
-                }
-                break;
-        }
     }
 }

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
@@ -370,4 +370,46 @@ public class StreamApi {
                 selectorId
         );
     }
+
+    // ----- PRIV
+    private List<PeerConnection.IceServer> getRTCConfiguration() {
+        return api.getTurnCredentials().stream().map(item ->
+                PeerConnection.IceServer.builder(item.url)
+                        .setUsername(item.username)
+                        .setPassword(item.password)
+                        .createIceServer()
+        ).collect(Collectors.toList());
+    }
+
+    private enum Mode {PUBLISHER, SUBSCRIBER}
+
+    private void setRTCConfiguration(Object key, Mode mode) {
+        RoomJanusSession session = key instanceof StreamHandle
+                ? pcManager.getSession((StreamHandle) key)
+                : pcManager.getSession((String) key);
+
+        if (session == null) {
+            throw new IllegalStateException(
+                    "No active session to this Stream Room. Join stream room first"
+            );
+        }
+
+        applyRTCConfiguration(session, mode);
+    }
+
+    private void applyRTCConfiguration(RoomJanusSession session, Mode mode) {
+        switch (mode) {
+            case PUBLISHER:
+                if (session.getPublisher() != null) {
+                    session.getPublisher().setRTCConfiguration(getRTCConfiguration());
+                }
+                break;
+
+            case SUBSCRIBER:
+                if (session.getSubscriber() != null) {
+                    session.getSubscriber().setRTCConfiguration(getRTCConfiguration());
+                }
+                break;
+        }
+    }
 }

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.simplito.java.privmx_endpoint.model.ConnectionType;
 import com.simplito.java.privmx_endpoint.model.ContainerPolicy;
 import com.simplito.java.privmx_endpoint.model.PagingList;
 import com.simplito.java.privmx_endpoint.model.UserWithPubKey;
@@ -262,13 +263,13 @@ public class StreamApi {
 
     public StreamPublishResult publishStream(StreamHandle streamHandle) {
         Objects.requireNonNull(streamHandle);
-        setRTCConfiguration(streamHandle, Mode.PUBLISHER);
+        setRTCConfiguration(streamHandle, ConnectionType.Publisher);
         return api.publishStream(streamHandle);
     }
 
     public StreamPublishResult updateStream(StreamHandle streamHandle) {
         Objects.requireNonNull(streamHandle);
-        setRTCConfiguration(streamHandle, Mode.PUBLISHER);
+        setRTCConfiguration(streamHandle, ConnectionType.Publisher);
         return api.updateStream(streamHandle);
     }
 
@@ -294,7 +295,7 @@ public class StreamApi {
             throw new IllegalStateException("No active session to this Stream Room. Join stream room first");
         try {
             session.createSubscriber();
-            setRTCConfiguration(streamRoomId, Mode.SUBSCRIBER);
+            setRTCConfiguration(streamRoomId, ConnectionType.Subscriber);
         } catch (IllegalStateException ignored) {}
         api.subscribeToRemoteStreams(streamRoomId, subscriptions, options);
     }
@@ -318,7 +319,7 @@ public class StreamApi {
             List<StreamSubscription> subscriptionsToRemove,
             Settings options
     ) {
-        setRTCConfiguration(streamRoomId, Mode.SUBSCRIBER);
+        setRTCConfiguration(streamRoomId, ConnectionType.Subscriber);
         api.modifyRemoteStreamsSubscriptions(
                 streamRoomId,
                 subscriptionsToAdd,
@@ -331,7 +332,7 @@ public class StreamApi {
             String streamRoomId,
             List<StreamSubscription> subscriptionsToRemove
     ) {
-        setRTCConfiguration(streamRoomId, Mode.SUBSCRIBER);
+        setRTCConfiguration(streamRoomId,ConnectionType.Subscriber);
         api.unsubscribeFromRemoteStreams(
                 streamRoomId,
                 subscriptionsToRemove
@@ -380,9 +381,7 @@ public class StreamApi {
         ).collect(Collectors.toList());
     }
 
-    private enum Mode {PUBLISHER, SUBSCRIBER}
-
-    private void setRTCConfiguration(Object key, Mode mode) {
+    private void setRTCConfiguration(Object key, ConnectionType mode) {
         RoomJanusSession session = key instanceof StreamHandle
                 ? pcManager.getSession((StreamHandle) key)
                 : pcManager.getSession((String) key);
@@ -396,15 +395,15 @@ public class StreamApi {
         applyRTCConfiguration(session, mode);
     }
 
-    private void applyRTCConfiguration(RoomJanusSession session, Mode mode) {
+    private void applyRTCConfiguration(RoomJanusSession session, ConnectionType mode) {
         switch (mode) {
-            case PUBLISHER:
+            case Publisher:
                 if (session.getPublisher() != null) {
                     session.getPublisher().setRTCConfiguration(getRTCConfiguration());
                 }
                 break;
 
-            case SUBSCRIBER:
+            case Subscriber:
                 if (session.getSubscriber() != null) {
                     session.getSubscriber().setRTCConfiguration(getRTCConfiguration());
                 }

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
@@ -23,6 +23,7 @@ import org.webrtc.DefaultVideoDecoderFactory;
 import org.webrtc.DefaultVideoEncoderFactory;
 import org.webrtc.EglBase;
 import org.webrtc.MediaStreamTrack;
+import org.webrtc.PeerConnection;
 import org.webrtc.PeerConnectionFactory;
 import org.webrtc.PmxFrameCryptor;
 import org.webrtc.VideoDecoderFactory;
@@ -31,7 +32,6 @@ import org.webrtc.VideoTrack;
 import org.webrtc.audio.AudioDeviceModule;
 import org.webrtc.audio.JavaAudioDeviceModule;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -165,8 +165,14 @@ public class StreamApi {
     public void joinStreamRoom(
             String streamRoomId
     ) {
+        List<PeerConnection.IceServer> iceServers = api.getTurnCredentials().stream().map(item -> PeerConnection.IceServer.builder(item.url)
+                .setUsername(item.username)
+                .setPassword(item.password)
+                .createIceServer()
+        ).collect(Collectors.toList());
+
         //TODO: Rollback this change, it is do only for run test
-        RoomJanusSession session = pcManager.createSession(streamRoomId);
+        RoomJanusSession session = pcManager.createSession(streamRoomId, iceServers);
         api.joinStreamRoom(streamRoomId, session.webrtc);
     }
 


### PR DESCRIPTION
## Description
TURN credentials are established during the initial PeerConnection setup.
Additionally, credentials must be fetched and refreshed when:
- Subscribing to or unsubscribing from remote streams
- Modifying remote stream subscriptions
- Publishing or updating a stream