### PR TITLE
[REFACTOR]: Remove unused options param

### DIFF
--- a/jni-wrappers/privmx-endpoint/src/cpp/modules/StreamApiLow.cpp
+++ b/jni-wrappers/privmx-endpoint/src/cpp/modules/StreamApiLow.cpp
@@ -665,19 +665,17 @@ Java_com_simplito_java_privmx_1endpoint_modules_stream_StreamApiLow_modifyRemote
         jobject thiz,
         jstring stream_room_id,
         jobject subscriptions_to_add,
-        jobject subscriptions_to_remove,
-        jobject options
+        jobject subscriptions_to_remove
 ) {
     JniContextUtils ctx(env);
     if (ctx.nullCheck(stream_room_id, "Stream Room ID") ||
         ctx.nullCheck(subscriptions_to_add, "Subscriptions to add") ||
-        ctx.nullCheck(subscriptions_to_add, "Subscriptions to remove") ||
-        ctx.nullCheck(options, "Options")) {
+        ctx.nullCheck(subscriptions_to_add, "Subscriptions to remove")) {
         return;
     }
 
     ctx.callVoidEndpointApi(
-            [&ctx, &thiz, &stream_room_id, &subscriptions_to_add, &subscriptions_to_remove, &options]() {
+            [&ctx, &thiz, &stream_room_id, &subscriptions_to_add, &subscriptions_to_remove]() {
                 auto subscriptions_to_add_arr = ctx.jObject2jArray(subscriptions_to_remove);
                 auto subscriptions_to_remove_arr = ctx.jObject2jArray(subscriptions_to_remove);
 

--- a/jni-wrappers/privmx-endpoint/src/cpp/modules/StreamApiLow.cpp
+++ b/jni-wrappers/privmx-endpoint/src/cpp/modules/StreamApiLow.cpp
@@ -706,16 +706,14 @@ Java_com_simplito_java_privmx_1endpoint_modules_stream_StreamApiLow_subscribeToR
         JNIEnv *env,
         jobject thiz,
         jstring stream_room_id,
-        jobject subscriptions,
-        jobject options
-) {
+        jobject subscriptions
+        ) {
     JniContextUtils ctx(env);
     if (ctx.nullCheck(stream_room_id, "Stream Room ID") ||
-        ctx.nullCheck(subscriptions, "Subscriptions") ||
-        ctx.nullCheck(options, "Options")) {
+        ctx.nullCheck(subscriptions, "Subscriptions")) {
         return;
     }
-    ctx.callVoidEndpointApi([&ctx, &thiz, &stream_room_id, &subscriptions, &options]() {
+    ctx.callVoidEndpointApi([&ctx, &thiz, &stream_room_id, &subscriptions]() {
         auto subscriptions_arr = ctx.jObject2jArray(subscriptions);
         auto subscriptions_c = jArrayToVector<StreamSubscription>(
                 ctx,

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
@@ -336,18 +336,6 @@ public class StreamApi implements AutoCloseable{
         api.subscribeToRemoteStreams(streamRoomId, subscriptions);
     }
 
-    public void modifyRemoteStreamsSubscriptions(
-            String streamRoomId,
-            List<StreamSubscription> subscriptionsToAdd,
-            List<StreamSubscription> subscriptionsToRemove
-    ) {
-        modifyRemoteStreamsSubscriptions(
-                streamRoomId,
-                subscriptionsToAdd,
-                subscriptionsToRemove,
-                new Settings()
-        );
-    }
 
     public void modifyRemoteStreamsSubscriptions(
             String streamRoomId,

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
@@ -9,7 +9,6 @@ import com.simplito.java.privmx_endpoint.model.ConnectionType;
 import com.simplito.java.privmx_endpoint.model.ContainerPolicy;
 import com.simplito.java.privmx_endpoint.model.PagingList;
 import com.simplito.java.privmx_endpoint.model.UserWithPubKey;
-import com.simplito.java.privmx_endpoint.model.stream.Settings;
 import com.simplito.java.privmx_endpoint.model.stream.StreamHandle;
 import com.simplito.java.privmx_endpoint.model.stream.StreamInfo;
 import com.simplito.java.privmx_endpoint.model.stream.StreamPublishResult;
@@ -354,8 +353,7 @@ public class StreamApi implements AutoCloseable{
     public void modifyRemoteStreamsSubscriptions(
             String streamRoomId,
             List<StreamSubscription> subscriptionsToAdd,
-            List<StreamSubscription> subscriptionsToRemove,
-            Settings options
+            List<StreamSubscription> subscriptionsToRemove
     ) {
         RoomJanusSession session = pcManager.getSession(streamRoomId);
         if (session == null)
@@ -366,8 +364,7 @@ public class StreamApi implements AutoCloseable{
         api.modifyRemoteStreamsSubscriptions(
                 streamRoomId,
                 subscriptionsToAdd,
-                subscriptionsToRemove,
-                options
+                subscriptionsToRemove
         );
     }
 

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
@@ -316,13 +316,6 @@ public class StreamApi implements AutoCloseable{
             String streamRoomId,
             List<StreamSubscription> subscriptions
     ) {
-        subscribeToRemoteStreams(streamRoomId, subscriptions, new Settings());
-    }
-
-    public void subscribeToRemoteStreams(
-            String streamRoomId,
-            List<StreamSubscription> subscriptions
-    ) {
         RoomJanusSession session = pcManager.getSession(streamRoomId);
         if (session == null)
             throw new IllegalStateException("No active session to this Stream Room. Join stream room first");

--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
@@ -321,8 +321,7 @@ public class StreamApi implements AutoCloseable{
 
     public void subscribeToRemoteStreams(
             String streamRoomId,
-            List<StreamSubscription> subscriptions,
-            Settings options
+            List<StreamSubscription> subscriptions
     ) {
         RoomJanusSession session = pcManager.getSession(streamRoomId);
         if (session == null)
@@ -334,7 +333,7 @@ public class StreamApi implements AutoCloseable{
         if (session.getSubscriber() == null)
             throw new IllegalStateException("This streamRoom has not created companion subscriber.");
         session.getSubscriber().setRTCConfiguration(getRTCConfiguration());
-        api.subscribeToRemoteStreams(streamRoomId, subscriptions, options);
+        api.subscribeToRemoteStreams(streamRoomId, subscriptions);
     }
 
     public void modifyRemoteStreamsSubscriptions(

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApiLow.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApiLow.java
@@ -15,7 +15,6 @@ import com.simplito.java.privmx_endpoint.model.ContainerPolicy;
 import com.simplito.java.privmx_endpoint.model.PagingList;
 import com.simplito.java.privmx_endpoint.model.UserWithPubKey;
 import com.simplito.java.privmx_endpoint.model.stream.SdpWithTypeModel;
-import com.simplito.java.privmx_endpoint.model.stream.Settings;
 import com.simplito.java.privmx_endpoint.model.stream.StreamEncryptionMode;
 import com.simplito.java.privmx_endpoint.model.stream.StreamHandle;
 import com.simplito.java.privmx_endpoint.model.stream.StreamInfo;
@@ -206,7 +205,7 @@ public class StreamApiLow implements AutoCloseable {
 
     public native void subscribeToRemoteStreams(String streamRoomId, List<StreamSubscription> subscriptions, Settings options);
 
-    public native void modifyRemoteStreamsSubscriptions(String streamRoomId, List<StreamSubscription> subscriptionsToAdd, List<StreamSubscription> subscriptionsToRemove, Settings options);
+    public native void modifyRemoteStreamsSubscriptions(String streamRoomId, List<StreamSubscription> subscriptionsToAdd, List<StreamSubscription> subscriptionsToRemove);
 
     public native void unsubscribeFromRemoteStreams(String streamRoomId, List<StreamSubscription> subscriptionsToRemove);
 

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApiLow.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApiLow.java
@@ -203,7 +203,7 @@ public class StreamApiLow implements AutoCloseable {
 
     public native void unpublishStream(StreamHandle streamHandle);
 
-    public native void subscribeToRemoteStreams(String streamRoomId, List<StreamSubscription> subscriptions, Settings options);
+    public native void subscribeToRemoteStreams(String streamRoomId, List<StreamSubscription> subscriptions);
 
     public native void modifyRemoteStreamsSubscriptions(String streamRoomId, List<StreamSubscription> subscriptionsToAdd, List<StreamSubscription> subscriptionsToRemove);
 


### PR DESCRIPTION
## Description
Remove options param from StreamApiLow and frma StreamApi for Android.
This parameter is no longer present in the C++ version.