### PR TITLE
refactor!: Remove creating temporary APIs from InboxApi and StreamApiLow constructor 

### DIFF
--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/inbox/InboxApi.java
@@ -50,19 +50,6 @@ public class InboxApi implements AutoCloseable {
     private final Long api;
 
     /**
-     * Creates Inbox from existing {@link Connection}.
-     *
-     * @param connection current connection
-     * @throws IllegalStateException when one of the passed parameters is closed.
-     */
-    public InboxApi(
-            Connection connection
-    ) throws IllegalStateException {
-        this(connection, null, null);
-    }
-
-
-    /**
      * Creates Inbox from existing {@link Connection}, {@link ThreadApi}, {@link StoreApi}.
      *
      * @param connection active connection to PrivMX Bridge
@@ -76,18 +63,13 @@ public class InboxApi implements AutoCloseable {
             StoreApi storeApi
     ) throws IllegalStateException {
         Objects.requireNonNull(connection);
-        StoreApi tmpStoreApi = storeApi == null ? new StoreApi(connection) : null;
-        ThreadApi tmpThreadApi = threadApi == null ? new ThreadApi(connection) : null;
+        Objects.requireNonNull(threadApi);
+        Objects.requireNonNull(storeApi);
         this.api = init(
                 connection,
-                Optional.ofNullable(threadApi).orElse(tmpThreadApi),
-                Optional.ofNullable(storeApi).orElse(tmpStoreApi)
+                threadApi,
+                storeApi
         );
-        try {
-            if (tmpThreadApi != null) tmpThreadApi.close();
-            if (tmpStoreApi != null) tmpStoreApi.close();
-        } catch (Exception ignore) {
-        }
     }
 
     private native Long init(

--- a/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApiLow.java
+++ b/privmx-endpoint/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApiLow.java
@@ -11,6 +11,7 @@
 
 package com.simplito.java.privmx_endpoint.modules.stream;
 
+import com.simplito.java.privmx_endpoint.LibLoader;
 import com.simplito.java.privmx_endpoint.model.ContainerPolicy;
 import com.simplito.java.privmx_endpoint.model.PagingList;
 import com.simplito.java.privmx_endpoint.model.UserWithPubKey;
@@ -33,10 +34,7 @@ import java.util.Optional;
 
 public class StreamApiLow implements AutoCloseable {
     static {
-//        System.loadLibrary("crypto");
-//        System.loadLibrary("ssl");
-//        System.loadLibrary("privmx-endpoint-java");
-//        System.loadLibrary("privmx-endpoint-streams-android");
+        LibLoader.loadPrivmxLibraries();
     }
 
     @SuppressWarnings("FieldCanBeLocal")
@@ -53,12 +51,6 @@ public class StreamApiLow implements AutoCloseable {
     ) throws IllegalStateException;
 
     public StreamApiLow(
-            Connection connection
-    ) throws IllegalStateException {
-        this.api = init(connection, null, StreamEncryptionMode.SINGLE_KEY);
-    }
-
-    public StreamApiLow(
             Connection connection,
             EventApi eventApi
     ) throws IllegalStateException {
@@ -71,17 +63,12 @@ public class StreamApiLow implements AutoCloseable {
             StreamEncryptionMode streamEncryptionMode
     ) throws IllegalStateException {
         Objects.requireNonNull(connection);
-        EventApi tmpEventApi = eventApi == null ? new EventApi(connection) : null;
+        Objects.requireNonNull(eventApi);
         this.api = init(
                 connection,
-                Optional.ofNullable(eventApi).orElse(tmpEventApi),
+                eventApi,
                 Optional.ofNullable(streamEncryptionMode).orElse(StreamEncryptionMode.SINGLE_KEY)
         );
-
-        try {
-            if (eventApi != null) tmpEventApi.close();
-        } catch (Exception ignore) {
-        }
     }
 
     public native List<TurnCredentials> getTurnCredentials();


### PR DESCRIPTION
Since the endpoint is now limited to one API instance per connection, exceeding this limit will cause initialization errors for subsequent APIs.