### PR TITLE
[FIX]: Remove closing StreamApiLow in StreamApi.close method

### DIFF
--- a/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
+++ b/privmx-endpoint-streams/android/src/main/java/com/simplito/java/privmx_endpoint/modules/stream/StreamApi.java
@@ -400,7 +400,6 @@ public class StreamApi implements AutoCloseable{
     public void close() throws Exception {
         pcManager.getRoomIds().forEach(this::leaveStreamRoom);
         pcManager.close();
-        api.close();
     }
 
     private List<PeerConnection.IceServer> getRTCConfiguration() {


### PR DESCRIPTION
## Description

The Stream API shouldn’t handle closing streams. Remove closing StreamApiLow in StreamApi.close method.
